### PR TITLE
add XMLName for structs with targetNamespace

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"runtime"
 
-	gen "github.com/tgulacsi/gowsdl/generator"
 	flags "github.com/jessevdk/go-flags"
+	gen "github.com/tgulacsi/gowsdl/generator"
 )
 
 const version = "v0.0.1"

--- a/generator/gowsdl.go
+++ b/generator/gowsdl.go
@@ -221,6 +221,7 @@ func (g *GoWsdl) genTypes() ([]byte, error) {
 		"stripns":              stripns,
 		"replaceReservedWords": replaceReservedWords,
 		"makePublic":           makePublic,
+		"getTargetNamespace":   func() string { return g.wsdl.TargetNamespace },
 	}
 
 	//TODO resolve element refs in place.

--- a/generator/header_tmpl.go
+++ b/generator/header_tmpl.go
@@ -6,6 +6,7 @@ package {{.}}
 // Do not modify
 // Copyright (c) 2014, Cloudescape. All rights reserved.
 import (
+	"encoding/xml"
 	"time"
 
 	gowsdl "github.com/cloudscape/gowsdl/generator"
@@ -16,4 +17,5 @@ import (
 
 // against "unused imports"
 var _ time.Time
+var _ xml.Name
 `

--- a/generator/soap.go
+++ b/generator/soap.go
@@ -28,7 +28,7 @@ type SoapHeader struct {
 }
 
 type SoapBody struct {
-	Body  string    `xml:",innerxml"`
+	Body  string     `xml:",innerxml"`
 	Fault *SoapFault `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
 }
 

--- a/generator/types_tmpl.go
+++ b/generator/types_tmpl.go
@@ -51,6 +51,7 @@ var typesTmpl = `
 	{{$name := replaceReservedWords .Name}}
 	{{with .ComplexType}}
 		type {{$name}} struct {
+			XMLName xml.Name ` + "`xml:\"{{getTargetNamespace}} {{$name}}\"`" + `
 			{{if ne .ComplexContent.Extension.Base ""}}
 				{{template "ComplexContent" .ComplexContent}}
 			{{else if ne .SimpleContent.Extension.Base ""}}

--- a/generator/xsd.go
+++ b/generator/xsd.go
@@ -6,7 +6,7 @@ import (
 
 type XsdSchema struct {
 	XMLName            xml.Name          `xml:"schema"`
-	Tns                string            `xml:"xmlns tns",attr`
+	Tns                string            `xml:"xmlns tns,attr"`
 	Xs                 string            `xml:"xmlns xs,attr"`
 	Version            string            `xml:"version,attr"`
 	TargetNamespace    string            `xml:"targetNamespace,attr"`


### PR DESCRIPTION
Some strange servers I have to deal with are picky about namespaces.
I need to include the target namespace for the struct.

An example is http://www.mnb.hu/arfolyamok.asmx?WSDL .

I don't know how this affects other generated clients...
