### PR TITLE
Improve godoc formatting

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -1,6 +1,7 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 package main
 
 import (

--- a/doc.go
+++ b/doc.go
@@ -3,50 +3,69 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 /*
-WSDL to Go
 
-Generates Go code from a WSDL file. This project is originally intended to generate Go clients for WS-* services.
+Gowsdl generates Go code from a WSDL file.
 
-### Features
-* Supports only Document/Literal wrapped services, which are [WS-I](http://ws-i.org/) compliant
-* Attempts to generate idiomatic Go code as much as possible
-* Generates Go code in parallel: types, operations and soap proxy
-* Supports:
-	* WSDL 1.1
-	* XML Schema 1.0
-	* SOAP 1.1
-* Resolves external XML Schemas recursively, up to 5 recursions.
-* Supports providing WSDL HTTP URL as well as a local WSDL file
+This project is originally intended to generate Go clients for WS-* services.
 
-### Not supported
-* Setting SOAP headers
-* SOAP 1.2 and HTTP port bindings
-* WS-Security
-* WS-Addressing
-* MTOM binary attachments
-* UDDI
-
-### Usage
-```
-gowsdl [OPTIONS]
+Usage:
+	gowsdl [OPTIONS]
 
 Application Options:
-  -v, --version     Shows gowsdl version
-  -p, --package=    Package under which code will be generated (myservice)
-  -o, --output=     File where the generated code will be saved (myservice.go)
-  -i, --ignore-tls  Ignores invalid TLS certificates. It is not recomended for production. Use at your own risk
-                    (false)
+	  -v, --version
+		Shows gowsdl version
+	  -p, --package=myservice
+		Package under which code will be generated
+	  -o, --output=myservice.go
+		File where the generated code will be saved
+	  -i, --ignore-tls
+		Ignores invalid TLS certificates. It is not recomended for production.
+		Use at your own risk.
+
 
 Help Options:
-  -h, --help        Show this help message
-```
+	  -h, --help
+		Show this help message
 
-### TODO
-* Add support for filters to allow the user to change the generated code
-* If WSDL file is local, resolve external XML schemas locally too instead of failing due to not having a URL to download them from.
-* Resolve XSD element references
-* Support for generating namespaces
-* Make code generation agnostic so generating code to other programming languages is feasible through plugins
+Features
+
+Supports only Document/Literal wrapped services, which are WS-I (http://ws-i.org/) compliant.
+
+Attempts to generate idiomatic Go code as much as possible.
+
+Generates Go code in parallel: types, operations and soap proxy.
+
+Supports WSDL 1.1, XML Schema 1.0, SOAP 1.1.
+
+Resolves external XML Schemas recursively, up to 5 recursions.
+
+Supports providing WSDL HTTP URL as well as a local WSDL file.
+
+Not supported
+
+Setting SOAP headers.
+
+SOAP 1.2 and HTTP port bindings.
+
+WS-Security.
+
+WS-Addressing.
+
+MTOM binary attachments.
+
+UDDI.
+
+TODO
+
+Add support for filters to allow the user to change the generated code.
+
+If WSDL file is local, resolve external XML schemas locally too instead of failing due to not having a URL to download them from.
+
+Resolve XSD element references.
+
+Support for generating namespaces.
+
+Make code generation agnostic so generating code to other programming languages is feasible through plugins.
 
 */
 package main

--- a/doc.go
+++ b/doc.go
@@ -1,6 +1,7 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 /*
 WSDL to Go
 


### PR DESCRIPTION
This PR improves the godoc formatting. godoc doesn't support markdown, so that has been removed. More bonuses are that the first line in the package documentation is no longer a license description, so it appears as something reasonable in package listings. Compare:

[old godoc](http://godoc.org/github.com/hooklift/gowsdl)

[new godoc](http://godoc.org/github.com/mjibson/gowsdl)