### PR TITLE
Set Request Close flag to set connection: close header

### DIFF
--- a/generator/soap.go
+++ b/generator/soap.go
@@ -90,6 +90,7 @@ func (s *SoapClient) Call(soapAction string, request, response interface{}) erro
 		req.Header.Add("SOAPAction", soapAction)
 	}
 	req.Header.Set("User-Agent", "gowsdl/0.1")
+	req.Close = true
 
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{


### PR DESCRIPTION
Using the SoapClient in parallel is exhausting the system with the "too many open files" error due to not closing the request socket after downloading the response.

This patch includes the flag "Close" on the Request object so that it sends the "connection: close" header and close the socket after reading the response.