### PR TITLE
Fix `make build`

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -7,7 +7,7 @@ test:
 	go test ./...
 
 build:
-	go build -o build/$(NAME) $(LDFLAGS) cmd/$(NAME).go
+	go build -o build/$(NAME) $(LDFLAGS) cmd/$(NAME)/main.go
 
 install:
 	go install $(LDFLAGS)


### PR DESCRIPTION
Looks like `make build` was broken by 13eb19f4e5612f4ab08b077b51d4f63b21f8ef7d. This fixed it for me.