### PR TITLE
XSD include caching incorrectly identifies multiple xsd files as the same file.

### DIFF
--- a/gowsdl.go
+++ b/gowsdl.go
@@ -185,8 +185,7 @@ func (g *GoWSDL) resolveXSDExternals(schema *XSDSchema, url *url.URL) error {
 			return err
 		}
 
-		_, schemaName := filepath.Split(location.Path)
-		if g.resolvedXSDExternals[schemaName] {
+		if g.resolvedXSDExternals[incl.SchemaLocation] {
 			continue
 		}
 
@@ -222,7 +221,7 @@ func (g *GoWSDL) resolveXSDExternals(schema *XSDSchema, url *url.URL) error {
 		if g.resolvedXSDExternals == nil {
 			g.resolvedXSDExternals = make(map[string]bool, maxRecursion)
 		}
-		g.resolvedXSDExternals[schemaName] = true
+		g.resolvedXSDExternals[incl.SchemaLocation] = true
 	}
 
 	return nil


### PR DESCRIPTION
The xsd file 'caching' is overly broad and identifies http://fqdn/some/endpoint?xsd=file1.xsd as the same include as http://fqdn/some/endpoint?xsd=file2.xsd. I think hosting several files at the same endpoint is fairly common practice, and I see no downsides to this change.

Thanks