### PR TITLE
Add additional err handling to SOAP template

### DIFF
--- a/soap_tmpl.go
+++ b/soap_tmpl.go
@@ -123,17 +123,20 @@ func (s *SOAPClient) Call(soapAction string, request, response interface{}) erro
 	encoder := xml.NewEncoder(buffer)
 	//encoder.Indent("  ", "    ")
 
-	err := encoder.Encode(envelope)
-	if err == nil {
-		err = encoder.Flush()
-	}
-
-	log.Println(buffer.String())
-	if err != nil {
+	if err := encoder.Encode(envelope); err != nil {
 		return err
 	}
 
+	if err := encoder.Flush(); err != nil {
+		return err
+	}
+
+	log.Println(buffer.String())
+
 	req, err := http.NewRequest("POST", s.url, buffer)
+	if err != nil {
+		return err
+	}
 	if s.auth != nil {
 		req.SetBasicAuth(s.auth.Login, s.auth.Password)
 	}
@@ -161,6 +164,9 @@ func (s *SOAPClient) Call(soapAction string, request, response interface{}) erro
 	defer res.Body.Close()
 
 	rawbody, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return err
+	}
 	if len(rawbody) == 0 {
 		log.Println("empty response")
 		return nil


### PR DESCRIPTION
These changes were proposed for the generated output file over at https://github.com/appropriate/go-virtualboxclient/pull/1 and I thought they seemed reasonable.

Please take a look! :+1: 