### PR TITLE
Support for element type ref attribute

### DIFF
--- a/gowsdl.go
+++ b/gowsdl.go
@@ -235,6 +235,7 @@ func (g *GoWSDL) genTypes() ([]byte, error) {
 		"replaceReservedWords": replaceReservedWords,
 		"makePublic":           makePublic,
 		"comment":              comment,
+		"removeNS":             removeNS,
 	}
 
 	//TODO resolve element refs in place.
@@ -373,6 +374,17 @@ var xsd2GoTypes = map[string]string{
 	"unsignedbyte":  "byte",
 	"unsignedlong":  "uint64",
 	"anytype":       "interface{}",
+}
+
+func removeNS(xsdType string) string {
+	// Handles name space, ie. xsd:string, xs:string
+	r := strings.Split(xsdType, ":")
+
+	if len(r) == 2 {
+		return r[1]
+	} else {
+		return r[0]
+	}
 }
 
 func toGoType(xsdType string) string {

--- a/types_tmpl.go
+++ b/types_tmpl.go
@@ -60,7 +60,18 @@ var typesTmpl = `
 {{end}}
 
 {{define "Elements"}}
-	{{range .}} {{if not .Type}} {{template "ComplexTypeInline" .}} {{else}} {{if .Doc}} {{.Doc | comment}} {{"\n"}} {{end}} {{replaceReservedWords .Name | makePublic}} {{if eq .MaxOccurs "unbounded"}}[]{{end}}{{.Type | toGoType}} ` + "`" + `xml:"{{.Name}},omitempty"` + "`" + ` {{end}}
+	{{range .}}
+		{{if ne .Ref ""}}
+			{{removeNS .Ref | replaceReservedWords  | makePublic}} {{if eq .MaxOccurs "unbounded"}}[]{{end}}{{.Ref | toGoType}} ` + "`" + `xml:"{{.Ref | removeNS}},omitempty"` + "`" + `
+		{{else}}
+		{{if not .Type}}
+			{{template "ComplexTypeInline" .}}
+		{{else}}
+			{{if .Doc}}
+				{{.Doc | comment}} {{"\n"}}
+			{{end}}
+			{{replaceReservedWords .Name | makePublic}} {{if eq .MaxOccurs "unbounded"}}[]{{end}}{{.Type | toGoType}} ` + "`" + `xml:"{{.Name}},omitempty"` + "`" + ` {{end}}
+		{{end}}
 	{{end}}
 {{end}}
 


### PR DESCRIPTION
I found gowsdl doesn't handle element's ref attribute like following:
```xml
<xs:element name="SearchBinSet">
<xs:complexType>
<xs:sequence>
<xs:element ref="tns:Bin" minOccurs="0" maxOccurs="unbounded"/>
</xs:sequence>
<xs:attribute name="NarrowBy" type="xs:string" use="required"/>
</xs:complexType>
</xs:element>
```
source: http://webservices.amazon.com/AWSECommerceService/AWSECommerceService.wsdl?rw_useCurrentProtocol=1

Gowsdl results a empty inline struct without name which cannot be compiled.
I modified types_tmpl.go to support this, after modification, it will generate code:
```go
type SearchBinSet struct {
	XMLName  xml.Name `xml:"http://webservices.amazon.com/AWSECommerceService/2013-08-01 SearchBinSet"`
	Bin      []*Bin `xml:"Bin,omitempty"`
	NarrowBy string `xml:"NarrowBy,attr,omitempty"`
}
```
After this enhancement, I can use gowsdl for generating structs of AWSECommerceService.wsdl. Still need a little tweaking for a few structs, like removing XMLName field or change union types to primitive types.

It would be nice to have it in gowsdl, I think it's probably the most complete wsdl code gen library in go.
Thanks.

Adrian Huang