### PR TITLE
Make export of generated structs optional

### DIFF
--- a/cmd/gowsdl/main.go
+++ b/cmd/gowsdl/main.go
@@ -67,6 +67,7 @@ var vers = flag.Bool("v", false, "Shows gowsdl version")
 var pkg = flag.String("p", "myservice", "Package under which code will be generated")
 var outFile = flag.String("o", "myservice.go", "File where the generated code will be saved")
 var insecure = flag.Bool("i", false, "Skips TLS Verification")
+var makePublic = flag.Bool("make-public", true, "Make the generated types public/exported")
 
 func init() {
 	log.SetFlags(0)
@@ -100,7 +101,7 @@ func main() {
 	}
 
 	// load wsdl
-	gowsdl, err := gen.NewGoWSDL(wsdlPath, *pkg, *insecure)
+	gowsdl, err := gen.NewGoWSDL(wsdlPath, *pkg, *insecure, *makePublic)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/gowsdl_test.go
+++ b/gowsdl_test.go
@@ -14,8 +14,9 @@ import (
 
 func TestElementGenerationDoesntCommentOutStructProperty(t *testing.T) {
 	g := GoWSDL{
-		file: "fixtures/test.wsdl",
-		pkg:  "myservice",
+		file:         "fixtures/test.wsdl",
+		pkg:          "myservice",
+		makePublicFn: makePublic,
 	}
 
 	resp, err := g.Start()
@@ -37,8 +38,9 @@ func TestVboxGeneratesWithoutSyntaxErrors(t *testing.T) {
 
 	for _, file := range files {
 		g := GoWSDL{
-			file: file,
-			pkg:  "myservice",
+			file:         file,
+			pkg:          "myservice",
+			makePublicFn: makePublic,
 		}
 
 		resp, err := g.Start()


### PR DESCRIPTION
We're using a Wsdl which has types similar in name but differing in capitalisation. 
At the moment gowsdl just makes all generated structs public by default which leads to "broken" (a.k.a. not compiling) Go files in our case.
I added the possibility to make the export of types optional. I remained the default to true so no current user should be affected when upgrading.