### PR TITLE
Allow clients to add SOAPHeader in SOAPClient.

### DIFF
--- a/gowsdl_test.go
+++ b/gowsdl_test.go
@@ -61,3 +61,19 @@ func TestVboxGeneratesWithoutSyntaxErrors(t *testing.T) {
 		}
 	}
 }
+
+func TestSOAPHeaderGeneratesWithoutErrors(t *testing.T) {
+	g := GoWSDL{
+		file:         "fixtures/ferry.wsdl",
+		pkg:          "myservice",
+		makePublicFn: makePublic,
+	}
+
+	resp, err := g.Start()
+	if err != nil {
+		t.Error(err)
+	}
+	if !strings.Contains(string(resp["operations"]), "SetHeader") {
+		t.Error("SetHeader method should be generated in the service operation")
+	}
+}

--- a/operations_tmpl.go
+++ b/operations_tmpl.go
@@ -22,6 +22,10 @@ var opsTmpl = `
 		}
 	}
 
+	func (service *{{$portType}}) SetHeader(header interface{}) {
+		service.client.SetHeader(header)
+	}
+
 	{{range .Operations}}
 		{{$faults := len .Faults}}
 		{{$requestType := findType .Input.Message | replaceReservedWords | makePublic}}

--- a/soap_tmpl.go
+++ b/soap_tmpl.go
@@ -13,7 +13,7 @@ func dialTimeout(network, addr string) (net.Conn, error) {
 
 type SOAPEnvelope struct {
 	XMLName xml.Name ` + "`" + `xml:"http://schemas.xmlsoap.org/soap/envelope/ Envelope"` + "`" + `
-
+	Header *SOAPHeader
 	Body SOAPBody
 }
 
@@ -48,6 +48,7 @@ type SOAPClient struct {
 	url string
 	tls bool
 	auth *BasicAuth
+	header interface{}
 }
 
 func (b *SOAPBody) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
@@ -112,9 +113,15 @@ func NewSOAPClient(url string, tls bool, auth *BasicAuth) *SOAPClient {
 	}
 }
 
+func (s *SOAPClient) SetHeader(header interface{}) {
+	s.header = header
+}
+
 func (s *SOAPClient) Call(soapAction string, request, response interface{}) error {
-	envelope := SOAPEnvelope{
-	//Header:        SoapHeader{},
+	envelope := SOAPEnvelope{}
+
+	if s.header != nil {
+		envelope.Header = &SOAPHeader{Header: s.header}
 	}
 
 	envelope.Body.Content = request


### PR DESCRIPTION
In order to allow the SOAPClient to send a
SOAPHeader without modification of generated code,
a new method SetHeader was added to both the
SOAPClient and to the generated operation.
The header, once set, is preserved between
invocations of other methods in the same instance.

This allows client code to call SetHeader()
with the desired header, including nil to remove
it from future calls in the same instance.

The SOAPHeader usually holds authentication info,
and we can benefit from reusing already set
credentials between invocations.

Please review and let me know if this could be merged upstream.
I don't know if it is possible for someone to test out this change
by generating client code to communicate with remote services,
and verify it is working as intended. I can confirm from logs
that the header is included, and it worked on a private site
I had to test the changes on.