### PR TITLE
Always export fields of structs

### DIFF
--- a/gowsdl.go
+++ b/gowsdl.go
@@ -240,6 +240,7 @@ func (g *GoWSDL) genTypes() ([]byte, error) {
 		"stripns":              stripns,
 		"replaceReservedWords": replaceReservedWords,
 		"makePublic":           g.makePublicFn,
+		"makeFieldPublic":      makePublic,
 		"comment":              comment,
 		"removeNS":             removeNS,
 	}

--- a/types_tmpl.go
+++ b/types_tmpl.go
@@ -30,9 +30,9 @@ var typesTmpl = `
 {{define "Attributes"}}
 	{{range .}}
 		{{if .Doc}} {{.Doc | comment}} {{end}} {{if not .Type}}
-			{{ .Name | makePublic}} {{toGoType .SimpleType.Restriction.Base}} ` + "`" + `xml:"{{.Name}},attr,omitempty"` + "`" + `
+			{{ .Name | makeFieldPublic}} {{toGoType .SimpleType.Restriction.Base}} ` + "`" + `xml:"{{.Name}},attr,omitempty"` + "`" + `
 		{{else}}
-			{{ .Name | makePublic}} {{toGoType .Type}} ` + "`" + `xml:"{{.Name}},attr,omitempty"` + "`" + `
+			{{ .Name | makeFieldPublic}} {{toGoType .Type}} ` + "`" + `xml:"{{.Name}},attr,omitempty"` + "`" + `
 		{{end}}
 	{{end}}
 {{end}}
@@ -70,7 +70,7 @@ var typesTmpl = `
 			{{if .Doc}}
 				{{.Doc | comment}} {{"\n"}}
 			{{end}}
-			{{replaceReservedWords .Name | makePublic}} {{if eq .MaxOccurs "unbounded"}}[]{{end}}{{.Type | toGoType}} ` + "`" + `xml:"{{.Name}},omitempty"` + "`" + ` {{end}}
+			{{replaceReservedWords .Name | makeFieldPublic}} {{if eq .MaxOccurs "unbounded"}}[]{{end}}{{.Type | toGoType}} ` + "`" + `xml:"{{.Name}},omitempty"` + "`" + ` {{end}}
 		{{end}}
 	{{end}}
 {{end}}


### PR DESCRIPTION
Recently we added the possibility to leave the defined types as they were defined in the wsdl, i.e. not making them public altogether. This can be switched on (in this case switched off) by a command line flag called `make-public` which defaults to true. The feature was introduced in #56 . 
This resolved some unwanted conflicts in some WSDLs, where there were different types with the same name only differentiated by capitalization.

I recently experienced that it also introduced another unwanted behaviour, i.e. fields within the types are also downcase/unexported which leads to broken Marshaling/Unmarshaling of XML.

This PR retains the ability to marshal the generated types, because only
exported fields are marshaled/unmarshaled by encoding/xml.