### PR TITLE
Don't mangle enumeration strings

### DIFF
--- a/gowsdl.go
+++ b/gowsdl.go
@@ -364,7 +364,7 @@ func replaceReservedWords(identifier string) string {
 // Normalizes value to be used as a valid Go identifier, avoiding compilation issues
 func normalize(value string) string {
 	mapping := func(r rune) rune {
-		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' {
 			return r
 		}
 		return -1

--- a/gowsdl.go
+++ b/gowsdl.go
@@ -257,6 +257,7 @@ func (g *GoWSDL) genTypes() ([]byte, error) {
 		"makeFieldPublic":      makePublic,
 		"comment":              comment,
 		"removeNS":             removeNS,
+		"goString":             goString,
 	}
 
 	//TODO resolve element refs in place.
@@ -371,6 +372,10 @@ func normalize(value string) string {
 	}
 
 	return strings.Map(mapping, value)
+}
+
+func goString(s string) string {
+	return strings.Replace(s, "\"", "\\\"", -1)
 }
 
 var xsd2GoTypes = map[string]string{

--- a/gowsdl_test.go
+++ b/gowsdl_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"go/format"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -76,4 +77,31 @@ func TestSOAPHeaderGeneratesWithoutErrors(t *testing.T) {
 	if !strings.Contains(string(resp["operations"]), "SetHeader") {
 		t.Error("SetHeader method should be generated in the service operation")
 	}
+}
+
+func TestEnumerationsGeneratedCorrectly(t *testing.T) {
+	enumStringTest := func(t *testing.T, fixtureWsdl string, varName string, typeName string, enumString string) {
+		g := GoWSDL{
+			file:         "fixtures/" + fixtureWsdl,
+			pkg:          "myservice",
+			makePublicFn: makePublic,
+		}
+
+		resp, err := g.Start()
+		if err != nil {
+			t.Error(err)
+		}
+
+		re := regexp.MustCompile(varName + " " + typeName + " = \"([^\"]+)\"")
+		matches := re.FindStringSubmatch(string(resp["types"]))
+
+		if len(matches) != 2 {
+			t.Errorf("No match or too many matches found for %s", varName)
+		} else if matches[1] != enumString {
+			t.Errorf("%s got '%s' but expected '%s'", varName, matches[1], enumString)
+		}
+	}
+	enumStringTest(t, "chromedata.wsdl", "DriveTrainFrontWheelDrive", "DriveTrain", "Front Wheel Drive")
+	enumStringTest(t, "vboxweb.wsdl", "SettingsVersionV1_14", "SettingsVersion", "v1_14")
+
 }

--- a/types_tmpl.go
+++ b/types_tmpl.go
@@ -12,7 +12,7 @@ var typesTmpl = `
 		{{with .Restriction}}
 			{{range .Enumeration}}
 				{{if .Doc}} {{.Doc | comment}} {{end}}
-				{{$type}}{{$value := replaceReservedWords .Value}}{{$value | makePublic}} {{$type}} = "{{$value}}" {{end}}
+				{{$type}}{{$value := replaceReservedWords .Value}}{{$value | makePublic}} {{$type}} = "{{.Value}}" {{end}}
 		{{end}}
 	)
 {{end}}

--- a/types_tmpl.go
+++ b/types_tmpl.go
@@ -12,7 +12,7 @@ var typesTmpl = `
 		{{with .Restriction}}
 			{{range .Enumeration}}
 				{{if .Doc}} {{.Doc | comment}} {{end}}
-				{{$type}}{{$value := replaceReservedWords .Value}}{{$value | makePublic}} {{$type}} = "{{.Value}}" {{end}}
+				{{$type}}{{$value := replaceReservedWords .Value}}{{$value | makePublic}} {{$type}} = "{{goString .Value}}" {{end}}
 		{{end}}
 	)
 {{end}}


### PR DESCRIPTION
Previously this was using the same string as the variable name and the string value. Additionally underscores were not preserved in the var name - as they are valid in a go identifier I figure they probably should be.