### PR TITLE
Added basic support for WSS Security header

### DIFF
--- a/header_tmpl.go
+++ b/header_tmpl.go
@@ -8,15 +8,15 @@ var headerTmpl = `
 package {{.}}
 
 import (
+	"bytes"
+	"crypto/tls"
 	"encoding/xml"
-	"time"
- 	"bytes"
- 	"crypto/tls"
- 	"encoding/xml"
- 	"io/ioutil"
-	"net/http"
+	"io/ioutil"
 	"log"
+	"math/rand"
 	"net"
+	"net/http"
+	"time"
 
 	{{/*range .Imports*/}}
 		{{/*.*/}}

--- a/operations_tmpl.go
+++ b/operations_tmpl.go
@@ -22,8 +22,13 @@ var opsTmpl = `
 		}
 	}
 
+	func (service *{{$portType}}) AddHeader(header interface{}) {
+		service.client.AddHeader(header)
+	}
+
+	// Backwards-compatible function: use AddHeader instead
 	func (service *{{$portType}}) SetHeader(header interface{}) {
-		service.client.SetHeader(header)
+		service.client.AddHeader(header)
 	}
 
 	{{range .Operations}}


### PR DESCRIPTION
New structs WSSSecurityHeader, WSSUsernameToken and its child structs WSSUsername and WSSPassword. XML namespace problems are dealt with by using vania-pooh's workaround:  https://github.com/golang/go/issues/9519#issuecomment-252196382

Convenience function `NewWSSSecurityHeader` to ease header creation (the header is not automatically added to the SOAP client).

`SetHeader` method is kept for compatibility. There is a new `AddHeader` method to add headers to the SOAP call. There is now support for several headers instead of only one.

Cosmetic changes in header_tmpl.go to sort import names alphabetically.

Sample code:

> // "1" is for 'mustUnderstand' attribute; empty if not specified
> hdr := myservice.NewWSSSecurityHeader("sampleuser", "samplepassword", "1")
> myserviceClient.AddHeader(hdr)

