### PR TITLE
Have includes download from same namespace where they were included

### DIFF
--- a/gowsdl.go
+++ b/gowsdl.go
@@ -67,6 +67,10 @@ func downloadFile(url string, ignoreTLS bool) ([]byte, error) {
 	}
 
 	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("Received response code %d", resp.StatusCode)
+	}
+
 	data, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
@@ -185,7 +189,7 @@ func (g *GoWSDL) unmarshal() error {
 }
 
 func (g *GoWSDL) resolveXSDExternals(schema *XSDSchema, u *url.URL) error {
-	download := func(u1 *url.URL, loc string) error{
+	download := func(u1 *url.URL, loc string) error {
 		location, err := u1.Parse(loc)
 		if err != nil {
 			return err
@@ -206,6 +210,10 @@ func (g *GoWSDL) resolveXSDExternals(schema *XSDSchema, u *url.URL) error {
 		log.Println("Downloading external schema", "location", schemaLocation)
 
 		data, err := downloadFile(schemaLocation, g.ignoreTLS)
+		if err != nil {
+			return err
+		}
+
 		newschema := new(XSDSchema)
 
 		err = xml.Unmarshal(data, newschema)
@@ -215,11 +223,13 @@ func (g *GoWSDL) resolveXSDExternals(schema *XSDSchema, u *url.URL) error {
 
 		if len(newschema.Includes) > 0 &&
 			maxRecursion > g.currentRecursionLevel {
-
 			g.currentRecursionLevel++
 
-			//log.Printf("Entering recursion %d\n", g.currentRecursionLevel)
-			g.resolveXSDExternals(newschema, u1)
+			// log.Printf("Entering recursion %d\n", g.currentRecursionLevel)
+			err = g.resolveXSDExternals(newschema, u1)
+			if err != nil {
+				return err
+			}
 		}
 
 		g.wsdl.Types.Schemas = append(g.wsdl.Types.Schemas, newschema)
@@ -232,15 +242,14 @@ func (g *GoWSDL) resolveXSDExternals(schema *XSDSchema, u *url.URL) error {
 		return nil
 	}
 
-
 	for _, impts := range schema.Imports {
-		if e := download(u, impts.SchemaLocation); e!= nil {
+		if e := download(u, impts.SchemaLocation); e != nil {
 			return e
 		}
 	}
 
 	for _, incl := range schema.Includes {
-		if e := download(u, incl.SchemaLocation); e!= nil {
+		if e := download(u, schema.TargetNamespace+"/"+incl.SchemaLocation); e != nil {
 			return e
 		}
 	}


### PR DESCRIPTION
Re: #81 

After this change the includes for the ONVIF specification are downloaded properly, and 404 error are properly surfaced.