### PR TITLE
Replace poop emoji with thumbs up

### DIFF
--- a/cmd/gowsdl/main.go
+++ b/cmd/gowsdl/main.go
@@ -136,5 +136,5 @@ func main() {
 
 	file.Write(source)
 
-	log.Println("Done 💩")
+	log.Println("Done 👍")
 }


### PR DESCRIPTION
It's confusing to get a poop emoji as a result when the generation was successful.