### PR TITLE
Fix echo of "*String" type instead of the correct parameter struct type

### DIFF
--- a/gowsdl.go
+++ b/gowsdl.go
@@ -463,7 +463,7 @@ func (g *GoWSDL) findType(message string) string {
 			continue
 		}
 
-		part := msg.Parts[0]
+		part := msg.Parts[len(msg.Parts)-1]
 		if part.Type != "" {
 			return stripns(part.Type)
 		}


### PR DESCRIPTION
Still not ideal, but seems that, when there are more elements in this node, the right one will be the last one.

Closes #45