### PR TITLE
Fix dereference of schemaLocation attribute on <include>

### DIFF
--- a/gowsdl.go
+++ b/gowsdl.go
@@ -249,7 +249,7 @@ func (g *GoWSDL) resolveXSDExternals(schema *XSDSchema, u *url.URL) error {
 	}
 
 	for _, incl := range schema.Includes {
-		if e := download(u, schema.TargetNamespace+"/"+incl.SchemaLocation); e != nil {
+		if e := download(u, incl.SchemaLocation); e != nil {
 			return e
 		}
 	}


### PR DESCRIPTION
According to [XSD spec](https://www.w3.org/TR/xmlschema11-1/#schema-loc) there is no difference between dereferencing `schemaLocation` in `xsd:include` and `xsd:import`.

> When schema location values (i.e. `schemaLocation` attributes on `<include>`, `<redefine>`, `<override>`, and `<import>` in schema documents, or `xsi:schemaLocation` and `xsi:noNamespaceSchemaLocation` attributes in instance documents) are dereferenced and the values are relative references, then the [base URI] of the [owner element] must be used to resolve the relative references.