### PR TITLE
Fix complex type with simple type

### DIFF
--- a/fixtures/test.wsdl
+++ b/fixtures/test.wsdl
@@ -1,10 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
-<wsdl:definitions xmlns:s="http://www.w3.org/2001/XMLSchema" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:tns="http://www.mnb.hu/webservices/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tm="http://microsoft.com/wsdl/mime/textMatching/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" targetNamespace="http://www.mnb.hu/webservices/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">
+<wsdl:definitions xmlns:s="http://www.w3.org/2001/XMLSchema"
+                  xmlns:tns="http://www.mnb.hu/webservices/"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:http="http://schemas.xmlsoap.org/wsdl/http/"
+                  targetNamespace="http://www.mnb.hu/webservices/"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">
   <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">MNB curreny exchange rate webservice.</wsdl:documentation>
   <wsdl:types>
     <s:schema elementFormDefault="qualified" targetNamespace="http://www.mnb.hu/webservices/">
       <s:element name="GetInfo">
-        <s:complexType />
+        <s:complexType>
+          <s:sequence>
+            <s:element name="Id">
+              <s:annotation>
+                <s:documentation>comment</s:documentation>
+              </s:annotation>
+              <s:simpleType>
+                <s:restriction base="s:string">
+                  <s:minLength value="2"/>
+                </s:restriction>
+              </s:simpleType>
+            </s:element>
+          </s:sequence>
+        </s:complexType>
       </s:element>
       <s:element name="GetInfoResponse">
         <s:complexType>
@@ -25,13 +43,27 @@
   <wsdl:message name="GetInfoSoapOut">
     <wsdl:part name="parameters" element="tns:GetInfoResponse" />
   </wsdl:message>
+  <wsdl:portType name="MNBArfolyamServiceType">
+    <wsdl:operation name="GetInfoSoap">
+      <wsdl:input message="tns:GetInfoSoapIn"/>
+      <wsdl:output message="tns:GetInfoSoapOut"/>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="MNBArfolyamBinding" type="tns:MNBArfolyamServiceType">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http" />
+    <wsdl:operation name="GetInfoSoap">
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
   <wsdl:service name="MNBArfolyamService">
     <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">MNB curreny exchange rate webservice.</wsdl:documentation>
-    <wsdl:port name="MNBArfolyamServiceSoap" binding="tns:MNBArfolyamServiceSoap">
-      <soap:address location="http://www.mnb.hu/arfolyamok.asmx" />
-    </wsdl:port>
-    <wsdl:port name="MNBArfolyamServiceSoap12" binding="tns:MNBArfolyamServiceSoap12">
-      <soap12:address location="http://www.mnb.hu/arfolyamok.asmx" />
+    <wsdl:port name="MNBArfolyamServiceSoap" binding="tns:MNBArfolyamBinding">
+      <soap:address location="http://example.org/" />
     </wsdl:port>
   </wsdl:service>
 </wsdl:definitions>

--- a/types_tmpl.go
+++ b/types_tmpl.go
@@ -7,7 +7,9 @@ package gowsdl
 var typesTmpl = `
 {{define "SimpleType"}}
 	{{$type := replaceReservedWords .Name | makePublic}}
+	{{if .Doc}} {{.Doc | comment}} {{end}}
 	type {{$type}} {{toGoType .Restriction.Base}}
+	{{if .Restriction.Enumeration}}
 	const (
 		{{with .Restriction}}
 			{{range .Enumeration}}
@@ -15,6 +17,7 @@ var typesTmpl = `
 				{{$type}}{{$value := replaceReservedWords .Value}}{{$value | makePublic}} {{$type}} = "{{goString .Value}}" {{end}}
 		{{end}}
 	)
+	{{end}}
 {{end}}
 
 {{define "ComplexContent"}}
@@ -65,11 +68,14 @@ var typesTmpl = `
 			{{removeNS .Ref | replaceReservedWords  | makePublic}} {{if eq .MaxOccurs "unbounded"}}[]{{end}}{{.Ref | toGoType}} ` + "`" + `xml:"{{.Ref | removeNS}},omitempty"` + "`" + `
 		{{else}}
 		{{if not .Type}}
-			{{template "ComplexTypeInline" .}}
-		{{else}}
-			{{if .Doc}}
-				{{.Doc | comment}} {{"\n"}}
+			{{if .SimpleType}}
+				{{if .Doc}} {{.Doc | comment}} {{end}}
+				{{ .Name | makeFieldPublic}} {{toGoType .SimpleType.Restriction.Base}} ` + "`" + `xml:"{{.Name}},omitempty"` + "`" + `
+			{{else}}
+				{{template "ComplexTypeInline" .}}
 			{{end}}
+		{{else}}
+			{{if .Doc}}{{.Doc | comment}} {{end}}
 			{{replaceReservedWords .Name | makeFieldPublic}} {{if eq .MaxOccurs "unbounded"}}[]{{end}}{{.Type | toGoType}} ` + "`" + `xml:"{{.Name}},omitempty"` + "`" + ` {{end}}
 		{{end}}
 	{{end}}

--- a/xsd.go
+++ b/xsd.go
@@ -110,6 +110,7 @@ type XSDAttribute struct {
 // and information about the values of attributes or text-only elements.
 type XSDSimpleType struct {
 	Name        string         `xml:"name,attr"`
+	Doc         string         `xml:"annotation>documentation"`
 	Restriction XSDRestriction `xml:"restriction"`
 }
 


### PR DESCRIPTION
gowsdl for XSD:
```
<s:element name="GetInfo">
  <s:complexType>
    <s:sequence>
      <s:element name="Id">
        <s:annotation>
          <s:documentation>comment</s:documentation>
        </s:annotation>
        <s:simpleType>
          <s:restriction base="s:string">
            <s:minLength value="2"/>
          </s:restriction>
        </s:simpleType>
      </s:element>
    </s:sequence>
  </s:complexType>
</s:element>
```

generates next code, where `Id` is an empty struct:
```
type GetInfo struct {
	XMLName	xml.Name	`xml:"http://www.mnb.hu/webservices/ GetInfo"`

	Id	struct {
	}	`xml:"Id,omitempty"`
} 
```

With this pull request it will generate it as:
```
type GetInfo struct {
	XMLName	xml.Name	`xml:"http://www.mnb.hu/webservices/ GetInfo"`

	Id	string	`xml:"Id,omitempty"`
}
```