### PR TITLE
Fix schemaLocation dereferencing of relative path

### DIFF
--- a/gowsdl.go
+++ b/gowsdl.go
@@ -199,17 +199,18 @@ func (g *GoWSDL) resolveXSDExternals(schema *XSDSchema, u *url.URL) error {
 			return nil
 		}
 
-		schemaLocation := location.String()
 		if !location.IsAbs() {
 			if !u1.IsAbs() {
-				return fmt.Errorf("Unable to resolve external schema %s through WSDL URL %s", schemaLocation, u1)
+				return fmt.Errorf("Unable to resolve external schema %s through WSDL URL %s", location.String(), u1)
 			}
-			schemaLocation = u1.Scheme + "://" + u1.Host + schemaLocation
+			if location, err = url.Parse(u1.Scheme + "://" + u1.Host + location.String()); err != nil {
+				return err
+			}
 		}
 
-		log.Println("Downloading external schema", "location", schemaLocation)
+		log.Println("Downloading external schema", "location", location.String())
 
-		data, err := downloadFile(schemaLocation, g.ignoreTLS)
+		data, err := downloadFile(location.String(), g.ignoreTLS)
 		if err != nil {
 			return err
 		}
@@ -225,8 +226,7 @@ func (g *GoWSDL) resolveXSDExternals(schema *XSDSchema, u *url.URL) error {
 			maxRecursion > g.currentRecursionLevel {
 			g.currentRecursionLevel++
 
-			// log.Printf("Entering recursion %d\n", g.currentRecursionLevel)
-			err = g.resolveXSDExternals(newschema, u1)
+			err = g.resolveXSDExternals(newschema, location)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Before:
```
$ gowsdl https://www.onvif.org/onvif/ver10/device/wsdl/devicemgmt.wsdl
🍀  Downloading file https://www.onvif.org/onvif/ver10/device/wsdl/devicemgmt.wsdl
🍀  Downloading external schema location https://www.onvif.org/onvif/ver10/schema/onvif.xsd
🍀  Downloading external schema location http://www.w3.org/2005/05/xmlmime
🍀  Downloading external schema location http://www.w3.org/2003/05/soap-envelope
🍀  Downloading external schema location http://docs.oasis-open.org/wsn/b-2.xsd
🍀  Downloading external schema location http://www.w3.org/2004/08/xop/include
🍀  Downloading external schema location https://www.onvif.org/onvif/ver10/device/wsdl/common.xsd
🍀  Received response code 404
```

After:
```
$ gowsdl https://www.onvif.org/onvif/ver10/device/wsdl/devicemgmt.wsdl
🍀  Downloading file https://www.onvif.org/onvif/ver10/device/wsdl/devicemgmt.wsdl
🍀  Downloading external schema location https://www.onvif.org/onvif/ver10/schema/onvif.xsd
🍀  Downloading external schema location http://www.w3.org/2005/05/xmlmime
🍀  Downloading external schema location http://www.w3.org/2003/05/soap-envelope
🍀  Downloading external schema location http://docs.oasis-open.org/wsn/b-2.xsd
🍀  Downloading external schema location http://www.w3.org/2004/08/xop/include
🍀  Downloading external schema location https://www.onvif.org/onvif/ver10/schema/common.xsd
🍀  genTypes error template: types:30:54: executing "Attributes" at <.SimpleType.Restrict...>: can't evaluate field Restriction in type *gowsdl.XSDSimpleType
🍀  Done 👍
```