### PR TITLE
updated operations_tmpl for empty response

### DIFF
--- a/operations_tmpl.go
+++ b/operations_tmpl.go
@@ -54,14 +54,12 @@ var opsTmpl = `
 		// {{range .Faults}}
 		//   - {{.Name}} {{.Doc}}{{end}}{{end}}
 		{{if ne .Doc ""}}/* {{.Doc}} */{{end}}
-		func (service *{{$portType}}) {{makePublic .Name | replaceReservedWords}} ({{if ne $requestType ""}}request *{{$requestType}}{{end}}) (*{{$responseType}}, error) {
-			response := new({{$responseType}})
-			err := service.client.Call("{{$soapAction}}", {{if ne $requestType ""}}request{{else}}nil{{end}}, response)
-			if err != nil {
-				return nil, err
+		func (service *{{$portType}}) {{makePublic .Name | replaceReservedWords}} ({{if ne $requestType ""}}request *{{$requestType}}{{end}}) ({{if ne $responseType ""}}response *{{$responseType}}, {{end}}err error) {
+			response {{if ne $responseType ""}}= new({{$responseType}}){{else}}:= new(interface{}){{end}}
+			if err = service.client.Call("{{$soapAction}}", {{if ne $requestType ""}}request{{else}}nil{{end}}, response); err != nil {
+				{{if ne $responseType ""}}response = nil{{end}}
 			}
-
-			return response, nil
+			return
 		}
 		{{/*end*/}}
 	{{end}}


### PR DESCRIPTION
Updated template to handle empty responses.

Error occurs on [wsdl](https://blueantasp36.proventis.net/demonew/services/BaseService\?wsdl)
before:
```go
        func (service *Base) Logout (request *LogoutRequestParameter) (*, error) {
            response := new()
            err := service.client.Call("http://blueant.axis.proventis.net/Logout", request, response)
            if err != nil {
                return nil, err
            }

            return response, nil
        }
```

after:
```go
func (service *Base) Logout(request *LogoutRequestParameter) (err error) {
    response := new(interface{})
    if err = service.client.Call("http://blueant.axis.proventis.net/Logout", request, response); err != nil {

    }
    return
}
```

```go
func (service *Base) Login(request *LoginRequestParameter) (response *Session, err error) {
    response = new(Session)
    if err = service.client.Call("http://blueant.axis.proventis.net/Login", request, response); err != nil {
        response = nil
    }
    return
}
```
fixes #68 
fixes #93 