### PR TITLE
feat: generate public service interfaces

### DIFF
--- a/gowsdl.go
+++ b/gowsdl.go
@@ -287,6 +287,7 @@ func (g *GoWSDL) genOperations() ([]byte, error) {
 		"stripns":              stripns,
 		"replaceReservedWords": replaceReservedWords,
 		"makePublic":           g.makePublicFn,
+		"makePrivate":          makePrivate,
 		"findType":             g.findType,
 		"findSOAPAction":       g.findSOAPAction,
 		"findServiceAddress":   g.findServiceAddress,
@@ -530,6 +531,16 @@ func makePublic(identifier string) string {
 	}
 
 	field[0] = unicode.ToUpper(field[0])
+	return string(field)
+}
+
+func makePrivate(identifier string) string {
+	field := []rune(identifier)
+	if len(field) == 0 {
+		return identifier
+	}
+
+	field[0] = unicode.ToLower(field[0])
 	return string(field)
 }
 

--- a/operations_tmpl.go
+++ b/operations_tmpl.go
@@ -6,55 +6,69 @@ package gowsdl
 
 var opsTmpl = `
 {{range .}}
-	{{$portType := .Name | makePublic}}
-	type {{$portType}} struct {
+	{{$privateType := .Name | makePrivate}}
+	{{$exportType := .Name | makePublic}}
+
+	type {{$exportType}} interface {
+		AddHeader(header interface{})
+		SetHeader(header interface{})
+		{{range .Operations}}
+			{{$faults := len .Faults}}
+			{{$soapAction := findSOAPAction .Name $privateType}}
+			{{$requestType := findType .Input.Message | replaceReservedWords | makePublic}}
+			{{$responseType := findType .Output.Message | replaceReservedWords | makePublic}}
+
+			{{/*if ne $soapAction ""*/}}
+			{{if gt $faults 0}}
+			// Error can be either of the following types:
+			// {{range .Faults}}
+			//   - {{.Name}} {{.Doc}}{{end}}{{end}}
+			{{if ne .Doc ""}}/* {{.Doc}} */{{end}}
+			{{makePublic .Name | replaceReservedWords}} ({{if ne $requestType ""}}request *{{$requestType}}{{end}}) (*{{$responseType}}, error)
+			{{/*end*/}}
+		{{end}}
+	}
+
+	type {{$privateType}} struct {
 		client *SOAPClient
 	}
 
-	func New{{$portType}}(url string, tls bool, auth *BasicAuth) *{{$portType}} {
+	func New{{$exportType}}(url string, tls bool, auth *BasicAuth) {{$exportType}} {
 		if url == "" {
 			url = {{findServiceAddress .Name | printf "%q"}}
 		}
 		client := NewSOAPClient(url, tls, auth)
 
-		return &{{$portType}}{
+		return &{{$privateType}}{
 			client: client,
 		}
 	}
 
-	func New{{$portType}}WithTLSConfig(url string, tlsCfg *tls.Config, auth *BasicAuth) *{{$portType}} {
+	func New{{$exportType}}WithTLSConfig(url string, tlsCfg *tls.Config, auth *BasicAuth) {{$exportType}} {
 		if url == "" {
 			url = {{findServiceAddress .Name | printf "%q"}}
 		}
 		client := NewSOAPClientWithTLSConfig(url, tlsCfg, auth)
 
-		return &{{$portType}}{
+		return &{{$privateType}}{
 			client: client,
 		}
 	}
 
-	func (service *{{$portType}}) AddHeader(header interface{}) {
+	func (service *{{$privateType}}) AddHeader(header interface{}) {
 		service.client.AddHeader(header)
 	}
 
 	// Backwards-compatible function: use AddHeader instead
-	func (service *{{$portType}}) SetHeader(header interface{}) {
+	func (service *{{$privateType}}) SetHeader(header interface{}) {
 		service.client.AddHeader(header)
 	}
 
 	{{range .Operations}}
-		{{$faults := len .Faults}}
 		{{$requestType := findType .Input.Message | replaceReservedWords | makePublic}}
-		{{$soapAction := findSOAPAction .Name $portType}}
+		{{$soapAction := findSOAPAction .Name $privateType}}
 		{{$responseType := findType .Output.Message | replaceReservedWords | makePublic}}
-
-		{{/*if ne $soapAction ""*/}}
-		{{if gt $faults 0}}
-		// Error can be either of the following types:
-		// {{range .Faults}}
-		//   - {{.Name}} {{.Doc}}{{end}}{{end}}
-		{{if ne .Doc ""}}/* {{.Doc}} */{{end}}
-		func (service *{{$portType}}) {{makePublic .Name | replaceReservedWords}} ({{if ne $requestType ""}}request *{{$requestType}}{{end}}) (*{{$responseType}}, error) {
+		func (service *{{$privateType}}) {{makePublic .Name | replaceReservedWords}} ({{if ne $requestType ""}}request *{{$requestType}}{{end}}) (*{{$responseType}}, error) {
 			response := new({{$responseType}})
 			err := service.client.Call("{{$soapAction}}", {{if ne $requestType ""}}request{{else}}nil{{end}}, response)
 			if err != nil {
@@ -63,7 +77,6 @@ var opsTmpl = `
 
 			return response, nil
 		}
-		{{/*end*/}}
 	{{end}}
 {{end}}
 `


### PR DESCRIPTION
This PR changes how soap services are generated. Instead of returning service struct it will return interface for better testability.