### PR TITLE
Headers are no longer wrapped in a <Items> tag

### DIFF
--- a/soap/soap.go
+++ b/soap/soap.go
@@ -11,15 +11,9 @@ import (
 )
 
 type SOAPEnvelope struct {
-	XMLName xml.Name `xml:"http://schemas.xmlsoap.org/soap/envelope/ Envelope"`
-	Header  *SOAPHeader
+	XMLName xml.Name      `xml:"http://schemas.xmlsoap.org/soap/envelope/ Envelope"`
+	Headers []interface{} `xml:"http://schemas.xmlsoap.org/soap/envelope/ Header"`
 	Body    SOAPBody
-}
-
-type SOAPHeader struct {
-	XMLName xml.Name `xml:"http://schemas.xmlsoap.org/soap/envelope/ Header"`
-
-	Items []interface{} `xml:",omitempty"`
 }
 
 type SOAPBody struct {
@@ -220,9 +214,7 @@ func (s *Client) Call(soapAction string, request, response interface{}) error {
 	envelope := SOAPEnvelope{}
 
 	if s.headers != nil && len(s.headers) > 0 {
-		soapHeader := &SOAPHeader{Items: make([]interface{}, len(s.headers))}
-		copy(soapHeader.Items, s.headers)
-		envelope.Header = soapHeader
+		envelope.Headers = s.headers
 	}
 
 	envelope.Body.Content = request

--- a/wsdl.go
+++ b/wsdl.go
@@ -11,15 +11,15 @@ const wsdlNamespace = "http://schemas.xmlsoap.org/wsdl/"
 // WSDL represents the global structure of a WSDL file.
 type WSDL struct {
 	Xmlns           map[string]string `xml:"-"`
-	Name            string          `xml:"name,attr"`
-	TargetNamespace string          `xml:"targetNamespace,attr"`
-	Imports         []*WSDLImport   `xml:"import"`
-	Doc             string          `xml:"documentation"`
-	Types           WSDLType        `xml:"http://schemas.xmlsoap.org/wsdl/ types"`
-	Messages        []*WSDLMessage  `xml:"http://schemas.xmlsoap.org/wsdl/ message"`
-	PortTypes       []*WSDLPortType `xml:"http://schemas.xmlsoap.org/wsdl/ portType"`
-	Binding         []*WSDLBinding  `xml:"http://schemas.xmlsoap.org/wsdl/ binding"`
-	Service         []*WSDLService  `xml:"http://schemas.xmlsoap.org/wsdl/ service"`
+	Name            string            `xml:"name,attr"`
+	TargetNamespace string            `xml:"targetNamespace,attr"`
+	Imports         []*WSDLImport     `xml:"import"`
+	Doc             string            `xml:"documentation"`
+	Types           WSDLType          `xml:"http://schemas.xmlsoap.org/wsdl/ types"`
+	Messages        []*WSDLMessage    `xml:"http://schemas.xmlsoap.org/wsdl/ message"`
+	PortTypes       []*WSDLPortType   `xml:"http://schemas.xmlsoap.org/wsdl/ portType"`
+	Binding         []*WSDLBinding    `xml:"http://schemas.xmlsoap.org/wsdl/ binding"`
+	Service         []*WSDLService    `xml:"http://schemas.xmlsoap.org/wsdl/ service"`
 }
 
 // UnmarshalXML implements interface xml.Unmarshaler for XSDSchema.


### PR DESCRIPTION
The way it is implemented now, all headers will always be wrapped in a <Items> tag.

```
<Header>
    <Items>
        <Any headers are added here>
    </Items>
</Header>
```

Now headers are added correctly inside the top level <Header> tag

```
<Header>
    <Any headers are added here>
</Header>
```