### PR TITLE
Read imports from xsd files as well

### DIFF
--- a/gowsdl.go
+++ b/gowsdl.go
@@ -214,7 +214,7 @@ func (g *GoWSDL) resolveXSDExternals(schema *XSDSchema, loc *Location) error {
 			return err
 		}
 
-		if len(newschema.Includes) > 0 &&
+		if (len(newschema.Includes) > 0 || len(newschema.Imports) > 0) &&
 			maxRecursion > g.currentRecursionLevel {
 			g.currentRecursionLevel++
 


### PR DESCRIPTION
If a xsd file imports other xsd files, it was not processing them. Only
includes were processed correctly, this commit will also recursively
read and process import statements.