### PR TITLE
support generating arrays of simple types

### DIFF
--- a/types_tmpl.go
+++ b/types_tmpl.go
@@ -8,7 +8,12 @@ var typesTmpl = `
 {{define "SimpleType"}}
 	{{$type := replaceReservedWords .Name | makePublic}}
 	{{if .Doc}} {{.Doc | comment}} {{end}}
-	type {{$type}} {{toGoType .Restriction.Base}}
+	{{if ne .List.ItemType ""}}
+		type {{$type}} []{{toGoType .List.ItemType }}
+	{{else}}
+		type {{$type}} {{toGoType .Restriction.Base}}
+	{{end}}
+
 	{{if .Restriction.Enumeration}}
 	const (
 		{{with .Restriction}}


### PR DESCRIPTION
Adapt simple type template to support generation of slices.
I.e., generate a slice if an item type is given.