### PR TITLE
Feature/rudimentary support for unions

### DIFF
--- a/gowsdl.go
+++ b/gowsdl.go
@@ -258,6 +258,7 @@ func (g *GoWSDL) resolveXSDExternals(schema *XSDSchema, loc *Location) error {
 func (g *GoWSDL) genTypes() ([]byte, error) {
 	funcMap := template.FuncMap{
 		"toGoType":              toGoType,
+		"unionToGoStringType":   unionToGoStringType,
 		"stripns":               stripns,
 		"replaceReservedWords":  replaceReservedWords,
 		"makePublic":            g.makePublicFn,
@@ -426,6 +427,11 @@ func toGoType(xsdType string) string {
 	}
 
 	return "*" + replaceReservedWords(makePublic(t))
+}
+
+
+func unionToGoStringType(xsdType string) string {
+	return "string"
 }
 
 func removePointerFromType(goType string) string {

--- a/gowsdl.go
+++ b/gowsdl.go
@@ -258,7 +258,6 @@ func (g *GoWSDL) resolveXSDExternals(schema *XSDSchema, loc *Location) error {
 func (g *GoWSDL) genTypes() ([]byte, error) {
 	funcMap := template.FuncMap{
 		"toGoType":              toGoType,
-		"unionToGoStringType":   unionToGoStringType,
 		"stripns":               stripns,
 		"replaceReservedWords":  replaceReservedWords,
 		"makePublic":            g.makePublicFn,
@@ -427,11 +426,6 @@ func toGoType(xsdType string) string {
 	}
 
 	return "*" + replaceReservedWords(makePublic(t))
-}
-
-
-func unionToGoStringType(xsdType string) string {
-	return "string"
 }
 
 func removePointerFromType(goType string) string {

--- a/types_tmpl.go
+++ b/types_tmpl.go
@@ -11,7 +11,9 @@ var typesTmpl = `
 	{{if ne .List.ItemType ""}}
 		type {{$type}} []{{toGoType .List.ItemType }}
 	{{else if ne .Union.MemberTypes ""}}
-		type {{$type}} {{unionToGoStringType .Union.MemberTypes}}
+		type {{$type}} string
+	{{else if .Union.SimpleType}}
+		type {{$type}} string
 	{{else}}
 		type {{$type}} {{toGoType .Restriction.Base}}
 	{{end}}

--- a/types_tmpl.go
+++ b/types_tmpl.go
@@ -10,6 +10,8 @@ var typesTmpl = `
 	{{if .Doc}} {{.Doc | comment}} {{end}}
 	{{if ne .List.ItemType ""}}
 		type {{$type}} []{{toGoType .List.ItemType }}
+	{{else if ne .Union.MemberTypes ""}}
+		type {{$type}} {{unionToGoStringType .Union.MemberTypes}}
 	{{else}}
 		type {{$type}} {{toGoType .Restriction.Base}}
 	{{end}}


### PR DESCRIPTION
There was no proper code generated for XML union types.
To ensure compatibility with all inputs, make each union a string.