### PR TITLE
force empty soap action to exist in the generated request

### DIFF
--- a/operations_tmpl.go
+++ b/operations_tmpl.go
@@ -45,7 +45,7 @@ var opsTmpl = `
 		{{$responseType := findType .Output.Message | replaceReservedWords | makePublic}}
 		func (service *{{$privateType}}) {{makePublic .Name | replaceReservedWords}}Context (ctx context.Context, {{if ne $requestType ""}}request *{{$requestType}}{{end}}) ({{if ne $responseType ""}}*{{$responseType}}, {{end}}error) {
 			{{if ne $responseType ""}}response := new({{$responseType}}){{end}}
-			err := service.client.CallContext(ctx, "{{$soapAction}}", {{if ne $requestType ""}}request{{else}}nil{{end}}, {{if ne $responseType ""}}response{{else}}struct{}{}{{end}})
+			err := service.client.CallContext(ctx, "{{if ne $soapAction ""}}{{$soapAction}}{{else}}''{{end}}", {{if ne $requestType ""}}request{{else}}nil{{end}}, {{if ne $responseType ""}}response{{else}}struct{}{}{{end}})
 			if err != nil {
 				return {{if ne $responseType ""}}nil, {{end}}err
 			}


### PR DESCRIPTION
For operations with an empty soap action the client would omit the soap action field entirely which would make the request invalid with some APIs.
Adding an explicit empty string to the request seems to resolve that issue