### PR TITLE
fix incorrect marshalling of SOAP headers

### DIFF
--- a/soap/soap.go
+++ b/soap/soap.go
@@ -21,9 +21,15 @@ type SOAPDecoder interface {
 }
 
 type SOAPEnvelope struct {
-	XMLName xml.Name      `xml:"http://schemas.xmlsoap.org/soap/envelope/ Envelope"`
-	Headers []interface{} `xml:"http://schemas.xmlsoap.org/soap/envelope/ Header"`
+	XMLName xml.Name `xml:"http://schemas.xmlsoap.org/soap/envelope/ Envelope"`
+	Header  *SOAPHeader
 	Body    SOAPBody
+}
+
+type SOAPHeader struct {
+	XMLName xml.Name `xml:"http://schemas.xmlsoap.org/soap/envelope/ Header"`
+
+	Headers []interface{}
 }
 
 type SOAPBody struct {
@@ -280,7 +286,9 @@ func (s *Client) call(ctx context.Context, soapAction string, request, response 
 	envelope := SOAPEnvelope{}
 
 	if s.headers != nil && len(s.headers) > 0 {
-		envelope.Headers = s.headers
+		envelope.Header = &SOAPHeader{
+			Headers: s.headers,
+		}
 	}
 
 	envelope.Body.Content = request

--- a/soap/soap.go
+++ b/soap/soap.go
@@ -268,6 +268,7 @@ func NewClient(url string, opt ...Option) *Client {
 }
 
 // AddHeader adds envelope header
+// For correct behavior, every header must contain a `XMLName` field.  Refer to #121 for details
 func (s *Client) AddHeader(header interface{}) {
 	s.headers = append(s.headers, header)
 }


### PR DESCRIPTION
SOAP headers were not wrapped in `<Header></Header>` tags and were
instead marshaled directly into the `<Envelope>` tag.

I encountered this problem while trying to use `wss := soap.NewWSSSecurityHeader(...)` followed by `client.AddHeader(wss)`.  
Before this fix, the `<Security>` tags were marshaled directly inside the `<Envelope>` tag, not within a `<Header>` tag as expected.

Very similar to the patch suggested in #147 but allows for the header element to be ignored by the marshaller if no headers have been added.

fixes #147
