### PR TITLE
support default namespace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/hooklift/gowsdl
+
+go 1.12

--- a/gowsdl.go
+++ b/gowsdl.go
@@ -255,6 +255,22 @@ func (g *GoWSDL) resolveXSDExternals(schema *XSDSchema, loc *Location) error {
 }
 
 func (g *GoWSDL) genTypes() ([]byte, error) {
+
+	globalTargetNamespace := ""
+
+	setTargetNamespace := func(ns string) string {
+		globalTargetNamespace = ns
+		return ""
+	}
+
+	getQualifiedName := func(name string) string {
+		if globalTargetNamespace != "" {
+			return globalTargetNamespace + " " + name
+		} else {
+			return name
+		}
+	}
+
 	funcMap := template.FuncMap{
 		"toGoType":              toGoType,
 		"stripns":               stripns,
@@ -266,6 +282,8 @@ func (g *GoWSDL) genTypes() ([]byte, error) {
 		"goString":              goString,
 		"findNameByType":        g.findNameByType,
 		"removePointerFromType": removePointerFromType,
+		"setTargetNamespace":    setTargetNamespace,
+		"getQualifiedName":      getQualifiedName,
 	}
 
 	data := new(bytes.Buffer)

--- a/types_tmpl.go
+++ b/types_tmpl.go
@@ -81,22 +81,22 @@ var typesTmpl = `
 			{{if .SimpleType}}
 				{{if .Doc}} {{.Doc | comment}} {{end}}
 				{{if ne .SimpleType.List.ItemType ""}}
-					{{ .Name | makeFieldPublic}} []{{toGoType .SimpleType.List.ItemType}} ` + "`" + `xml:"{{.Name}},omitempty"` + "`" + `
+					{{ .Name | makeFieldPublic}} []{{toGoType .SimpleType.List.ItemType}} ` + "`" + `xml:"{{getQualifiedName .Name}},omitempty"` + "`" + `
 				{{else}}
-					{{ .Name | makeFieldPublic}} {{toGoType .SimpleType.Restriction.Base}} ` + "`" + `xml:"{{.Name}},omitempty"` + "`" + `
+					{{ .Name | makeFieldPublic}} {{toGoType .SimpleType.Restriction.Base}} ` + "`" + `xml:"{{getQualifiedName .Name}},omitempty"` + "`" + `
 				{{end}}
 			{{else}}
 				{{template "ComplexTypeInline" .}}
 			{{end}}
 		{{else}}
 			{{if .Doc}}{{.Doc | comment}} {{end}}
-			{{replaceReservedWords .Name | makeFieldPublic}} {{if eq .MaxOccurs "unbounded"}}[]{{end}}{{.Type | toGoType}} ` + "`" + `xml:"{{.Name}},omitempty"` + "`" + ` {{end}}
+			{{replaceReservedWords .Name | makeFieldPublic}} {{if eq .MaxOccurs "unbounded"}}[]{{end}}{{.Type | toGoType}} ` + "`" + `xml:"{{getQualifiedName .Name}},omitempty"` + "`" + ` {{end}}
 		{{end}}
 	{{end}}
 {{end}}
 
 {{range .Schemas}}
-	{{ $targetNamespace := .TargetNamespace }}
+	{{setTargetNamespace .TargetNamespace}}
 
 	{{range .SimpleType}}
 		{{template "SimpleType" .}}
@@ -108,7 +108,7 @@ var typesTmpl = `
 			{{/* ComplexTypeLocal */}}
 			{{with .ComplexType}}
 				type {{$name | replaceReservedWords | makePublic}} struct {
-					XMLName xml.Name ` + "`xml:\"{{$targetNamespace}} {{$name}}\"`" + `
+					XMLName xml.Name ` + "`xml:\"{{getQualifiedName $name}}\"`" + `
 					{{if ne .ComplexContent.Extension.Base ""}}
 						{{template "ComplexContent" .ComplexContent}}
 					{{else if ne .SimpleContent.Extension.Base ""}}
@@ -133,7 +133,7 @@ var typesTmpl = `
 		type {{$name}} struct {
 			{{$typ := findNameByType .Name}}
 			{{if ne $name $typ}}
-				XMLName xml.Name ` + "`xml:\"{{$targetNamespace}} {{$typ}}\"`" + `
+				XMLName xml.Name ` + "`xml:\"{{getQualifiedName $typ}}\"`" + `
 			{{end}}
 			{{if ne .ComplexContent.Extension.Base ""}}
 				{{template "ComplexContent" .ComplexContent}}
@@ -148,5 +148,8 @@ var typesTmpl = `
 			{{end}}
 		}
 	{{end}}
+
+	{{setTargetNamespace ""}}
+
 {{end}}
 `


### PR DESCRIPTION
This patch adds support for default targetNamespaces in xsds.

It repeats the full namespace in each xml-element, but it is sufficient to make my proprietary WSDLS  (Deutsche Telekom, SOABP) run againsts a crossfire client and server.

I found some existing code to support namespaces, but maybe this hack can be accepted as a stop-gap solution until the fully fledged system is implemented?