### PR TITLE
Fix setting context on request

### DIFF
--- a/soap/soap.go
+++ b/soap/soap.go
@@ -308,7 +308,7 @@ func (s *Client) call(ctx context.Context, soapAction string, request, response 
 		req.SetBasicAuth(s.opts.auth.Login, s.opts.auth.Password)
 	}
 
-	req.WithContext(ctx)
+	req = req.WithContext(ctx)
 
 	if s.opts.mtom {
 		req.Header.Add("Content-Type", fmt.Sprintf(mtomContentType, encoder.(*mtomEncoder).Boundary()))


### PR DESCRIPTION
From the docs on `request.WithContext`:

> WithContext returns a shallow copy of r with its context changed to ctx.

Currently, return value from `req.WithContext` is not used which means once they are issued, they cannot be canceled.