### PR TITLE
Avoid collision ComplexTypes Type name and resolve it.

### DIFF
--- a/traverser.go
+++ b/traverser.go
@@ -2,18 +2,21 @@ package gowsdl
 
 import (
 	"encoding/xml"
+	"fmt"
 	"strings"
 )
 
 type traverser struct {
-	c   *XSDSchema
-	all []*XSDSchema
+	c                 *XSDSchema
+	all               []*XSDSchema
+	resolveCollisions map[string]string
 }
 
-func newTraverser(c *XSDSchema, all []*XSDSchema) *traverser {
+func newTraverser(c *XSDSchema, all []*XSDSchema, resolveCollisions map[string]string) *traverser {
 	return &traverser{
-		c:   c,
-		all: all,
+		c:                 c,
+		all:               all,
+		resolveCollisions: resolveCollisions,
 	}
 }
 
@@ -41,6 +44,12 @@ func (t *traverser) traverseElement(elm *XSDElement) {
 	}
 	if elm.SimpleType != nil {
 		t.traverseSimpleType(elm.SimpleType)
+	}
+	{
+		ref := t.qname(elm.Type)
+		if updated, ok := t.resolveCollisions[fmt.Sprintf("%s/%s", ref.Space, ref.Local)]; ok {
+			elm.Type = updated
+		}
 	}
 }
 


### PR DESCRIPTION
Hi, it's still idea codes and I'm not good at soap. But I want to listen maintainers opinions. So I created p-r.

Some wsdl has same ComplexType name in different namespace schemas.
So currently we export it with syntax error (`Request redeclared in this block`), because we export all ComplexTypes to file as flat.

So this code found collision names, and rename it with number suffix.

```
    <wsdl:types>
        <xs:schema xmlns:ns1="xxx" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="vvv">
            <xs:complexType name="Request">
                <xs:sequence>
                          .....
                </xs:sequence>
            </xs:complexType>
        </xs:schema>
        <xs:schema xmlns:ns2="xxx" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="zzz">
            <xs:complexType name="Request">
                <xs:sequence>
                          .....
                </xs:sequence>
            </xs:complexType>
        </xs:schema>
        <xs:schema xmlns:ns1="vvv" xmlns:ns2="zzz"  attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="yyy">
            <xs:element name="do1">
                <xs:complexType>
                    <xs:sequence>
                        <xs:element minOccurs="0" name="param0" nillable="true" type="ns1:Request"/>
                    </xs:sequence>
                </xs:complexType>
            </xs:element>
            <xs:element name="do2">
                <xs:complexType>
                    <xs:sequence>
                        <xs:element minOccurs="0" name="param0" nillable="true" type="ns2:Request"/>
                    </xs:sequence>
                </xs:complexType>
            </xs:element>
        </xs:schema>
    </wsdl:types>
```
