### PR TITLE
Custom SOAPFault detail unmarshaling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ myservice
 build
 .DS_Store
 dist
+.idea/

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,5 @@
 module github.com/hooklift/gowsdl
+
+go 1.15
+
+require github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,11 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/soap/soap.go
+++ b/soap/soap.go
@@ -35,12 +35,13 @@ type SOAPHeader struct {
 type SOAPBody struct {
 	XMLName xml.Name `xml:"http://schemas.xmlsoap.org/soap/envelope/ Body"`
 
-	// 'faultOccurred' indicates whether the XML body included a fault;
+	Content interface{} `xml:",omitempty"`
+
+	// faultOccurred indicates whether the XML body included a fault;
 	// we cannot simply store SOAPFault as a pointer to indicate this, since
 	// fault is initialized to non-nil with user-provided detail type.
 	faultOccurred bool
-	Fault         *SOAPFault  `xml:",omitempty"`
-	Content       interface{} `xml:",omitempty"`
+	Fault         *SOAPFault `xml:",omitempty"`
 }
 
 // UnmarshalXML unmarshals SOAPBody xml
@@ -96,7 +97,11 @@ Loop:
 
 func (b *SOAPBody) ErrorFromFault() error {
 	if b.faultOccurred {
-		return fmt.Errorf("%s: %s", b.Fault.Code, b.Fault.String)
+		if b.Fault.String != "" {
+			return fmt.Errorf("%s: %s", b.Fault.Code, b.Fault.String)
+		} else {
+			return fmt.Errorf("unknown fault occurred")
+		}
 	}
 	b.Fault = nil
 	return nil

--- a/soap/soap_test.go
+++ b/soap/soap_test.go
@@ -3,9 +3,12 @@ package soap
 import (
 	"bytes"
 	"encoding/xml"
+	"fmt"
+	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -143,5 +146,119 @@ func TestClient_MTOM(t *testing.T) {
 
 	if reply.Attachment.ContentType() != req.Attachment.ContentType() {
 		t.Errorf("got %s wanted %s", reply.Attachment.Bytes(), req.Attachment.ContentType())
+	}
+}
+
+type SimpleDetail struct {
+	Node interface{} `xml:"SimpleNode"`
+}
+
+type SimpleNode struct {
+	Detail string      `xml:"Detail,omitempty"`
+	Num    float64     `xml:"Num,omitempty"`
+	Nested *SimpleNode `xml:"Nested,omitempty"`
+}
+
+func Test_CustomNestedFaul(t *testing.T) {
+	input := `<SimpleNode>
+  <Name>SimpleNode</Name>
+  <Detail>detail message</Detail>
+  <Num>6.005</Num>
+</SimpleNode>`
+	decoder := xml.NewDecoder(strings.NewReader(input))
+	var nested interface{}
+	nested = &SimpleNode{}
+	if err := decoder.Decode(&nested); err != nil {
+		t.Fatalf("error decoding: %v", err)
+	}
+	assert.EqualValues(t, &SimpleNode{
+		Detail: "detail message",
+		Num:    6.005,
+	}, nested)
+}
+
+func Test_Client_FaultDefault(t *testing.T) {
+	tests := []struct {
+		name       string
+		fault      interface{}
+		emptyFault interface{}
+	}{
+		{
+			name: "Empty",
+		},
+		{
+			name: "SimpleNode",
+			fault: &SimpleNode{
+				Detail: "detail message",
+				Num:    7.7,
+			},
+			emptyFault: &SimpleNode{},
+		},
+		{
+			name: "ArrayOfNode",
+			fault: &[]SimpleNode{
+				{
+					Detail: "detail message-1",
+					Num:    7.7,
+				}, {
+					Detail: "detail message-2",
+					Num:    7.8,
+				},
+			},
+			emptyFault: &[]SimpleNode{},
+		},
+		{
+			name: "NestedNode",
+			fault: &SimpleNode{
+				Detail: "detail-1",
+				Num:    .003,
+				Nested: &SimpleNode{
+					Detail: "nested-2",
+					Num:    .004,
+				},
+			},
+			emptyFault: &SimpleNode{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := xml.MarshalIndent(tt.fault, "\t\t\t\t", "\t")
+			if err != nil {
+				t.Fatalf("Failed to encode input as XML: %v", err)
+			}
+
+			var pingRequest = new(Ping)
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				xml.NewDecoder(r.Body).Decode(pingRequest)
+				rsp := fmt.Sprintf(`
+<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+	<soap:Body>
+		<soap:Fault>
+			<faultcode>soap:Server</faultcode>
+			<faultstring>Custom error message.</faultstring>
+			<detail>
+%v
+			</detail>
+		</soap:Fault>
+	</soap:Body>
+</soap:Envelope>`, string(data))
+				w.Write([]byte(rsp))
+			}))
+			defer ts.Close()
+
+			faultErrString := "soap:Server: Custom error message."
+
+			client := NewClient(ts.URL)
+			req := &Ping{Request: &PingRequest{Message: "Hi"}}
+			var reply PingResponse
+			fault := SimpleDetail{Node: tt.emptyFault}
+			if err := client.CallWithFault("GetData", req, &reply, &fault); err != nil {
+				assert.EqualError(t, err, faultErrString)
+				assert.EqualValues(t, tt.fault, fault.Node)
+			} else {
+				t.Fatalf("call to ping() should have failed, but succeeded.")
+			}
+		})
 	}
 }

--- a/soap/soap_test.go
+++ b/soap/soap_test.go
@@ -3,7 +3,6 @@ package soap
 import (
 	"bytes"
 	"encoding/xml"
-	"errors"
 	"fmt"
 	"github.com/stretchr/testify/assert"
 	"io/ioutil"
@@ -156,17 +155,13 @@ type SimpleNode struct {
 	Nested *SimpleNode `xml:"Nested,omitempty"`
 }
 
-func (s SimpleNode) String() string {
+func (s SimpleNode) ErrorString() string {
 	var sb strings.Builder
 	sb.WriteString(fmt.Sprintf("%.2f: %s", s.Num, s.Detail))
 	if s.Nested != nil {
-		sb.WriteString("\n" + s.Nested.String())
+		sb.WriteString("\n" + s.Nested.ErrorString())
 	}
 	return sb.String()
-}
-
-func (s SimpleNode) Error() error {
-	return errors.New(s.String())
 }
 
 func (s SimpleNode) HasData() bool {
@@ -182,12 +177,12 @@ func (w *Wrapper) HasData() bool {
 	return w.hasData
 }
 
-func (w *Wrapper) Error() error {
+func (w *Wrapper) ErrorString() string {
 	switch w.Item.(type) {
 	case FaultError:
-		return w.Item.(FaultError).Error()
+		return w.Item.(FaultError).ErrorString()
 	}
-	return errors.New("default error")
+	return "default error"
 }
 
 func Test_SimpleNode(t *testing.T) {
@@ -223,7 +218,7 @@ func Test_Client_FaultDefault(t *testing.T) {
 		},
 		{
 			name:          "Empty-NoFaultDetail",
-			wantErrString: "soap:Server: Custom error message.",
+			wantErrString: "Custom error message.",
 			hasData:       false,
 		},
 		{


### PR DESCRIPTION
https://github.com/hooklift/gowsdl/issues/180

### Background 
This PR fixes the described discrepancy between [SOAP 1.1 spec](https://www.w3.org/TR/2000/NOTE-SOAP-20000508/#_Ref477795996) and gowsdl implementation of fault detail.

### Overview of changes
Add a new function 
```
func (s *Client) 
CallWithFault(soapAction string, request, response, faultDetail interface{}) error
```

which allows to inject a custom fault detail type, similar to request and response.
Previously existing `Call` function remain backwards compatible and passes in `nil` for the fault, which is correctly handled (ignores detail information).

A slight awkwardness with this approach is: you cannot simply rely on Body.Fault == nil as a condition indicating there is no fault, since Fault is initialized with the custom detail type. Instead, there's a boolean `faultOccurred`, which is filled out during Body unmarshalling.

SOAPFault has to still be a pointer, since it has to be nil to pass a check in `TestClient_MTOM`, since it enforces that there are not multiple elements inside SOAP body.