### PR TITLE
Implemented choices inside complex type extensions

### DIFF
--- a/types_tmpl.go
+++ b/types_tmpl.go
@@ -38,6 +38,7 @@ var typesTmpl = `
 	{{end}}
 
 	{{template "Elements" .Extension.Sequence}}
+	{{template "Elements" .Extension.Choice}}
 	{{template "Attributes" .Extension.Attributes}}
 {{end}}
 
@@ -150,7 +151,7 @@ var typesTmpl = `
 				{{if ne $name $typ}}
 					XMLName xml.Name ` + "`xml:\"{{$targetNamespace}} {{$typ}}\"`" + `
 				{{end}}
-				
+
 				{{if ne .ComplexContent.Extension.Base ""}}
 					{{template "ComplexContent" .ComplexContent}}
 				{{else if ne .SimpleContent.Extension.Base ""}}
@@ -164,7 +165,7 @@ var typesTmpl = `
 					{{template "Attributes" .Attributes}}
 				{{end}}
 			}
-		{{end}}	
+		{{end}}
 	{{end}}
 {{end}}
 `

--- a/xsd.go
+++ b/xsd.go
@@ -23,7 +23,7 @@ type XSDSchema struct {
 	Imports            []*XSDImport      `xml:"import"`
 	Elements           []*XSDElement     `xml:"element"`
 	Attributes         []*XSDAttribute   `xml:"attribute"`
-	ComplexTypes       []*XSDComplexType `xml:"complexType"` //global
+	ComplexTypes       []*XSDComplexType `xml:"complexType"` // global
 	SimpleType         []*XSDSimpleType  `xml:"simpleType"`
 }
 
@@ -132,7 +132,7 @@ type XSDElement struct {
 	Ref         string          `xml:"ref,attr"`
 	MinOccurs   string          `xml:"minOccurs,attr"`
 	MaxOccurs   string          `xml:"maxOccurs,attr"`
-	ComplexType *XSDComplexType `xml:"complexType"` //local
+	ComplexType *XSDComplexType `xml:"complexType"` // local
 	SimpleType  *XSDSimpleType  `xml:"simpleType"`
 	Groups      []*XSDGroup     `xml:"group"`
 }
@@ -192,6 +192,7 @@ type XSDExtension struct {
 	Base       string          `xml:"base,attr"`
 	Attributes []*XSDAttribute `xml:"attribute"`
 	Sequence   []XSDElement    `xml:"sequence>element"`
+	Choice     []*XSDElement   `xml:"choice>element"`
 }
 
 // XSDAttribute represent an element attribute. Simple elements cannot have


### PR DESCRIPTION
Fixes #161 

In these cases the complex-type extension consists of a choice-set. These are not generated correctly so added the choice element template generation and choice type in the structure.