### PR TITLE
add nillable=true support for data fields

### DIFF
--- a/gowsdl.go
+++ b/gowsdl.go
@@ -455,7 +455,7 @@ func removeNS(xsdType string) string {
 	return r[0]
 }
 
-func toGoType(xsdType string) string {
+func toGoType(xsdType string, nillable bool) string {
 	// Handles name space, ie. xsd:string, xs:string
 	r := strings.Split(xsdType, ":")
 
@@ -468,6 +468,9 @@ func toGoType(xsdType string) string {
 	value := xsd2GoTypes[strings.ToLower(t)]
 
 	if value != "" {
+		if nillable {
+			value = "*" + value
+		}
 		return value
 	}
 


### PR DESCRIPTION
Hi,

Thanks for this gowsdl project, it helped a lot in our project. This is our 2 cents in supporting nillable=true attribute of WSDL, so that nillable fields can be identified in SOAP request and response, especially for fields of integer data types(int, int32, etc...).

We tried to read the gowsdl code generator design, and if we misunderstood anything, please don't hesitate to let us know, and we can update our code to make them right.

Thanks and regards