### PR TITLE
fix wrong Nillable field on XSDAttribute

### DIFF
--- a/types_tmpl.go
+++ b/types_tmpl.go
@@ -45,7 +45,7 @@ var typesTmpl = `
 	{{range .}}
 		{{if .Doc}} {{.Doc | comment}} {{end}}
 		{{ if ne .Type "" }}
-			{{ normalize .Name | makeFieldPublic}} {{toGoType .Type .Nillable}} ` + "`" + `xml:"{{.Name}},attr,omitempty" json:"{{.Name}},omitempty"` + "`" + `
+			{{ normalize .Name | makeFieldPublic}} {{toGoType .Type false}} ` + "`" + `xml:"{{.Name}},attr,omitempty" json:"{{.Name}},omitempty"` + "`" + `
 		{{ else }}
 			{{ normalize .Name | makeFieldPublic}} string ` + "`" + `xml:"{{.Name}},attr,omitempty" json:"{{.Name}},omitempty"` + "`" + `
 		{{ end }}


### PR DESCRIPTION
There is an error in handling XSDAttribute type. I have fixed it and now running go test shows "all passed":
```
...
Reading file /proj/work/huangnan/gitrepos/gowsdl/fixtures/epcis/BusinessScope.xsd
Reading file /proj/work/huangnan/gitrepos/gowsdl/fixtures/epcis/EPCglobal-epcis-query-1_2.xsd
PASS
ok      github.com/hooklift/gowsdl      1.504s

```