### PR TITLE
Pass HTTP status code to client if request fails

### DIFF
--- a/soap/soap.go
+++ b/soap/soap.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"encoding/xml"
 	"fmt"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"time"
@@ -131,6 +132,18 @@ func (f *SOAPFault) Error() string {
 		return f.Detail.ErrorString()
 	}
 	return f.String
+}
+
+// RequestError is returned whenever the HTTP request to the server fails
+type RequestError struct {
+	//StatusCode is the status code returned in the HTTP response
+	StatusCode int
+	//ResponseBody contains the body returned in the HTTP response
+	ResponseBody []byte
+}
+
+func (e *RequestError) Error() string {
+	return fmt.Sprintf("HTTP Status %d: %s", e.StatusCode, string(e.ResponseBody))
 }
 
 const (
@@ -314,7 +327,8 @@ func (s *Client) CallContext(ctx context.Context, soapAction string, request, re
 	return s.call(ctx, soapAction, request, response, nil)
 }
 
-// Call performs HTTP POST request
+// Call performs HTTP POST request.
+// Note that if the server returns a status code >= 400, a RequestError will be returned
 func (s *Client) Call(soapAction string, request, response interface{}) error {
 	return s.call(context.Background(), soapAction, request, response, nil)
 }
@@ -401,6 +415,14 @@ func (s *Client) call(ctx context.Context, soapAction string, request, response 
 		return err
 	}
 	defer res.Body.Close()
+
+	if res.StatusCode >= 400 {
+		body, _ := ioutil.ReadAll(res.Body)
+		return &RequestError{
+			StatusCode:   res.StatusCode,
+			ResponseBody: body,
+		}
+	}
 
 	respEnvelope := new(SOAPEnvelope)
 	respEnvelope.Body = SOAPBody{

--- a/soap/soap.go
+++ b/soap/soap.go
@@ -134,15 +134,15 @@ func (f *SOAPFault) Error() string {
 	return f.String
 }
 
-// RequestError is returned whenever the HTTP request to the server fails
-type RequestError struct {
+// HTTPError is returned whenever the HTTP request to the server fails
+type HTTPError struct {
 	//StatusCode is the status code returned in the HTTP response
 	StatusCode int
 	//ResponseBody contains the body returned in the HTTP response
 	ResponseBody []byte
 }
 
-func (e *RequestError) Error() string {
+func (e *HTTPError) Error() string {
 	return fmt.Sprintf("HTTP Status %d: %s", e.StatusCode, string(e.ResponseBody))
 }
 
@@ -328,7 +328,7 @@ func (s *Client) CallContext(ctx context.Context, soapAction string, request, re
 }
 
 // Call performs HTTP POST request.
-// Note that if the server returns a status code >= 400, a RequestError will be returned
+// Note that if the server returns a status code >= 400, a HTTPError will be returned
 func (s *Client) Call(soapAction string, request, response interface{}) error {
 	return s.call(context.Background(), soapAction, request, response, nil)
 }
@@ -418,7 +418,7 @@ func (s *Client) call(ctx context.Context, soapAction string, request, response 
 
 	if res.StatusCode >= 400 {
 		body, _ := ioutil.ReadAll(res.Body)
-		return &RequestError{
+		return &HTTPError{
 			StatusCode:   res.StatusCode,
 			ResponseBody: body,
 		}

--- a/soap/soap_test.go
+++ b/soap/soap_test.go
@@ -601,8 +601,8 @@ func TestXsdTime(t *testing.T) {
 	}
 }
 
-func TestRequestError(t *testing.T) {
-	type requestErrorTest struct {
+func TestHTTPError(t *testing.T) {
+	type httpErrorTest struct {
 		name         string
 		responseCode int
 		responseBody string
@@ -610,7 +610,7 @@ func TestRequestError(t *testing.T) {
 		wantErrMsg   string
 	}
 
-	tests := []requestErrorTest{
+	tests := []httpErrorTest{
 		{
 			name:         "should error if server returns 500",
 			responseCode: http.StatusInternalServerError,
@@ -655,9 +655,9 @@ func TestRequestError(t *testing.T) {
 				if gotErr == nil {
 					t.Fatalf("Expected an error from call.  Received none")
 				}
-				requestError, ok := gotErr.(*RequestError)
+				requestError, ok := gotErr.(*HTTPError)
 				if !ok {
-					t.Fatalf("Expected a RequestError.  Received: %s", gotErr.Error())
+					t.Fatalf("Expected a HTTPError.  Received: %s", gotErr.Error())
 				}
 
 				if requestError.StatusCode != test.responseCode {

--- a/soap/soap_test.go
+++ b/soap/soap_test.go
@@ -314,7 +314,7 @@ func Test_Client_FaultDefault(t *testing.T) {
 func TestXsdDateTime(t *testing.T) {
 	type TestDateTime struct {
 		XMLName  xml.Name `xml:"TestDateTime"`
-		Datetime XsdDateTime
+		Datetime XSDDateTime
 	}
 	// test marshalling
 	{
@@ -404,7 +404,7 @@ func TestXsdDateTime(t *testing.T) {
 func TestXsdDate(t *testing.T) {
 	type TestDate struct {
 		XMLName xml.Name `xml:"TestDate"`
-		Date    XsdDate
+		Date    XSDDate
 	}
 
 	// test marshalling
@@ -479,7 +479,7 @@ func TestXsdDate(t *testing.T) {
 func TestXsdTime(t *testing.T) {
 	type TestTime struct {
 		XMLName xml.Name `xml:"TestTime"`
-		Time    XsdTime
+		Time    XSDTime
 	}
 
 	// test marshalling


### PR DESCRIPTION
Same as #140, this adds the ability to get the HTTP status code returned from the server if the request fails.  

It appears tests in soap/soap_test.go were broken due to invalid struct names.  I fixed those as well in this PR so I could add tests for RequestError