### PR TITLE
Draft: Set namespace on request

### DIFF
--- a/gowsdl.go
+++ b/gowsdl.go
@@ -291,6 +291,7 @@ func (g *GoWSDL) genOperations() ([]byte, error) {
 		"findType":             g.findType,
 		"findSOAPAction":       g.findSOAPAction,
 		"findServiceAddress":   g.findServiceAddress,
+		"getTargetNamespace":   g.getTargetNamespace,
 	}
 
 	data := new(bytes.Buffer)
@@ -563,6 +564,10 @@ func (g *GoWSDL) findServiceAddress(name string) string {
 		}
 	}
 	return ""
+}
+
+func (g *GoWSDL) getTargetNamespace() string {
+	return g.wsdl.TargetNamespace
 }
 
 // TODO(c4milo): Add namespace support instead of stripping it

--- a/types_tmpl.go
+++ b/types_tmpl.go
@@ -148,9 +148,6 @@ var typesTmpl = `
 		{{else}}
 			type {{$name}} struct {
 				{{$typ := findNameByType .Name}}
-				{{if ne $name $typ}}
-					XMLName xml.Name ` + "`xml:\"{{$targetNamespace}} {{$typ}}\"`" + `
-				{{end}}
 
 				{{if ne .ComplexContent.Extension.Base ""}}
 					{{template "ComplexContent" .ComplexContent}}


### PR DESCRIPTION
I'm working with a system which differentiates between `<foo xmlns="something">` and `<ns:foo xmlns:ns="something">` (which I believe are equivalent?). This patch sets up the namespace alias on the body such that it works for my usecase, by wrapping the request object.

Reviewer note: I'm not sure this is generally correct! It currently breaks the tests, but as far as I can tell it is mainly because the generated output is different. I'm unsure if it breaks other systems, eg when there shouldn't be a namespace at all, if that is something which could happen?

cc @c4milo 
