### PR TITLE
Correctly generate `complexType`s which extend `string`.

### DIFF
--- a/fixtures/epcis/epcisquery.src
+++ b/fixtures/epcis/epcisquery.src
@@ -58,7 +58,11 @@ type Partner struct {
 	ContactInformation []*ContactInformation `xml:"ContactInformation,omitempty" json:"ContactInformation,omitempty"`
 }
 
-type PartnerIdentification string
+type PartnerIdentification struct {
+	Value string `xml:",chardata" json:"-,"`
+
+	Authority string `xml:"Authority,attr,omitempty" json:"Authority,omitempty"`
+}
 
 type ContactInformation struct {
 	Contact string `xml:"Contact,omitempty" json:"Contact,omitempty"`

--- a/fixtures/workday-time-min.wsdl
+++ b/fixtures/workday-time-min.wsdl
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:wd-wsdl="urn:com.workday/bsvc/Time_Tracking" xmlns:wd="urn:com.workday/bsvc" xmlns:nyw="urn:com.netyourwork/aod" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soapbind="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:httpbind="http://schemas.xmlsoap.org/wsdl/http/" xmlns:mimebind="http://schemas.xmlsoap.org/wsdl/mime/" name="Time_Tracking" targetNamespace="urn:com.workday/bsvc/Time_Tracking">
+  <wsdl:documentation>Operations for importing and exporting time and work schedule information.</wsdl:documentation>
+  <wsdl:types>
+    <xsd:schema elementFormDefault="qualified" attributeFormDefault="qualified" targetNamespace="urn:com.workday/bsvc">
+      <xsd:complexType name="WorkerObjectIDType">
+        <xsd:annotation>
+          <xsd:documentation>Contains a unique identifier for an instance of an object.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+          <xsd:extension base="xsd:string">
+            <xsd:attribute name="type" type="wd:WorkerReferenceEnumeration" use="required">
+              <xsd:annotation>
+                <xsd:documentation>The unique identifier type. Each "ID" for an instance of an object contains a type and a value. A single instance of an object can have multiple "ID" but only a single "ID" per "type".  Some "types" require a reference to a parent instance.</xsd:documentation>
+              </xsd:annotation>
+            </xsd:attribute>
+          </xsd:extension>
+        </xsd:simpleContent>
+      </xsd:complexType>
+    </xsd:schema>
+  </wsdl:types>
+</wsdl:definitions>

--- a/gowsdl_test.go
+++ b/gowsdl_test.go
@@ -153,6 +153,30 @@ func TestEnumerationsGeneratedCorrectly(t *testing.T) {
 
 }
 
+func TestComplexTypeGeneratedCorrectly(t *testing.T) {
+	g, err := NewGoWSDL("fixtures/workday-time-min.wsdl", "myservice", false, true)
+	if err != nil {
+		t.Error(err)
+	}
+
+	resp, err := g.Start()
+	if err != nil {
+		t.Error(err)
+	}
+
+	decl, err := getTypeDeclaration(resp, "WorkerObjectIDType")
+
+	expected := "type WorkerObjectIDType struct"
+	re := regexp.MustCompile(expected)
+	matches := re.FindStringSubmatch(decl)
+
+	if len(matches) != 1 {
+		t.Errorf("No match or too many matches found for WorkerObjectIDType")
+	} else if matches[0] != expected {
+		t.Errorf("WorkerObjectIDType got '%s' but expected '%s'", matches[1], expected)
+	}
+}
+
 func TestEPCISWSDL(t *testing.T) {
 	log.SetFlags(0)
 	log.SetOutput(os.Stdout)

--- a/types_tmpl.go
+++ b/types_tmpl.go
@@ -143,7 +143,7 @@ var typesTmpl = `
 	{{range .ComplexTypes}}
 		{{/* ComplexTypeGlobal */}}
 		{{$name := replaceReservedWords .Name | makePublic}}
-		{{if eq (toGoType .SimpleContent.Extension.Base false) "string"}}
+		{{if and (eq (len .SimpleContent.Extension.Attributes) 0) (eq (toGoType .SimpleContent.Extension.Base false) "string") }}
 			type {{$name}} string
 		{{else}}
 			type {{$name}} struct {


### PR DESCRIPTION
I decided to revisit #204, which I filed earlier this year.  The problem is that #166 add added [this special case in the `ComplexTypesGlobal` template](https://github.com/hooklift/gowsdl/blob/9e1cc9a7689230f4da66504844af631a0c4767cc/types_tmpl.go#L146-L148), which causes all `string`-extending `complexType`s to generate a `string` type alias.

I fully admit ignorance as to the specific reasons behind this behavior.  My fix is to change the template so it generates the string alias if the underlying type is `string` *and* there are no additional `xsd:attribute` elements.  This appears to fix my case while preserving whatever optimization the special case was for.

Making the change caused `TestEPCISWSDL` to fail, because `PartnerIdentification` in `Partner.xsd` is a `string`-extending `complexType`.  In other words, the generated code fixture was incorrect, and fixing the bug therefore broke the test.  The `EPC` type in `EPCglobal.xsd` is an example of a `string`-derived `complexType` with no further attributes; it correctly produces an output of:

    type EPC string

Therefore, I have updated `epcisquery.src` to match the new, corrected output.  I also added a test case for this, based on a pared-down [Workday Time_Tracking service](https://community.workday.com/sites/default/files/file-hosting/productionapi/Time_Tracking/v36.2/Time_Tracking.html) WSDL.

fixes #204