### PR TITLE
Support local simple types inside elements

### DIFF
--- a/fixtures/test.wsdl
+++ b/fixtures/test.wsdl
@@ -65,6 +65,26 @@
           </s:restriction>
         </s:simpleType>
       </s:attribute>
+      <!-- element with local simple type -->
+      <s:element name="elementWithLocalSimpleType">
+        <s:annotation>
+          <s:documentation>An element with a local simple type declaration including an enumeration.</s:documentation>
+        </s:annotation>
+        <s:simpleType>
+          <s:restriction base="s:string">
+            <s:enumeration value="enum1">
+              <s:annotation>
+                <s:documentation>First enum value</s:documentation>
+              </s:annotation>
+            </s:enumeration>
+            <s:enumeration value="enum2">
+              <s:annotation>
+                <s:documentation>Second enum value</s:documentation>
+              </s:annotation>
+            </s:enumeration>
+          </s:restriction>
+        </s:simpleType>
+      </s:element>
     </s:schema>
   </wsdl:types>
   <wsdl:message name="GetInfoSoapIn">

--- a/gowsdl_test.go
+++ b/gowsdl_test.go
@@ -95,6 +95,57 @@ func TestAttributeRef(t *testing.T) {
 	}
 }
 
+func TestElementWithLocalSimpleType(t *testing.T) {
+	g, err := NewGoWSDL("fixtures/test.wsdl", "myservice", false, true)
+	if err != nil {
+		t.Error(err)
+	}
+
+	resp, err := g.Start()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Type declaration
+	actual, err := getTypeDeclaration(resp, "ElementWithLocalSimpleType")
+	if err != nil {
+		fmt.Println(string(resp["types"]))
+		t.Fatal(err)
+	}
+
+	expected := `type ElementWithLocalSimpleType string`
+
+	if actual != expected {
+		t.Error("got \n" + actual + " want \n" + expected)
+	}
+
+	// Const declaration of first enum value
+	actual, err = getTypeDeclaration(resp, "ElementWithLocalSimpleTypeEnum1")
+	if err != nil {
+		fmt.Println(string(resp["types"]))
+		t.Fatal(err)
+	}
+
+	expected = `const ElementWithLocalSimpleTypeEnum1 ElementWithLocalSimpleType = "enum1"`
+
+	if actual != expected {
+		t.Error("got \n" + actual + " want \n" + expected)
+	}
+
+	// Const declaration of second enum value
+	actual, err = getTypeDeclaration(resp, "ElementWithLocalSimpleTypeEnum2")
+	if err != nil {
+		fmt.Println(string(resp["types"]))
+		t.Fatal(err)
+	}
+
+	expected = `const ElementWithLocalSimpleTypeEnum2 ElementWithLocalSimpleType = "enum2"`
+
+	if actual != expected {
+		t.Error("got \n" + actual + " want \n" + expected)
+	}
+}
+
 func TestVboxGeneratesWithoutSyntaxErrors(t *testing.T) {
 	files, err := filepath.Glob("fixtures/*.wsdl")
 	if err != nil {

--- a/types_tmpl.go
+++ b/types_tmpl.go
@@ -133,6 +133,32 @@ var typesTmpl = `
 					{{end}}
 				}
 			{{end}}
+			{{/* SimpleTypeLocal */}}
+			{{with .SimpleType}}
+				{{$type := replaceReservedWords $name | makePublic}}
+				{{if .Doc}} {{.Doc | comment}} {{end}}
+				{{if ne .List.ItemType ""}}
+					type {{$type}} []{{toGoType .List.ItemType false}}
+				{{else if ne .Union.MemberTypes ""}}
+					type {{$type}} string
+				{{else if .Union.SimpleType}}
+					type {{$type}} string
+				{{else if .Restriction.Base}}
+					type {{$type}} {{toGoType .Restriction.Base false}}
+				{{else}}
+					type {{$type}} interface{}
+				{{end}}
+			
+				{{if .Restriction.Enumeration}}
+				const (
+					{{with .Restriction}}
+						{{range .Enumeration}}
+							{{if .Doc}} {{.Doc | comment}} {{end}}
+							{{$type}}{{$value := replaceReservedWords .Value}}{{$value | makePublic}} {{$type}} = "{{goString .Value}}" {{end}}
+					{{end}}
+				)
+				{{end}}
+			{{end}}
 		{{else}}
 			{{if ne ($name | replaceReservedWords | makePublic) (toGoType .Type .Nillable | removePointerFromType)}}
 				type {{$name | replaceReservedWords | makePublic}} {{toGoType .Type .Nillable | removePointerFromType}}


### PR DESCRIPTION
For instance, this XSD definition:

```xsd
<xs:element name="myType">
  <xs:simpleType>
    <xs:restriction base="xs:string">
      <xs:minLength value="1"/>
    </xs:restriction>
  </xs:simpleType>
</xs:element>
```
    
shall result in this generated type definition:
```go
type myType string
```
    
The implementation approach is identical to the already existing support for local complex types. It basically copies the "SimpleType" template into the element processing when no Type is defined for the element.

A simple test with an enumeration has also been implemented
