### PR TITLE
Type generation: support extension>sequence>choice elements

### DIFF
--- a/types_tmpl.go
+++ b/types_tmpl.go
@@ -39,6 +39,7 @@ var typesTmpl = `
 
 	{{template "Elements" .Extension.Sequence}}
 	{{template "Elements" .Extension.Choice}}
+	{{template "Elements" .Extension.SequenceChoice}}
 	{{template "Attributes" .Extension.Attributes}}
 {{end}}
 

--- a/xsd.go
+++ b/xsd.go
@@ -188,11 +188,12 @@ type XSDSimpleContent struct {
 
 // XSDExtension element extends an existing simpleType or complexType element.
 type XSDExtension struct {
-	XMLName    xml.Name        `xml:"extension"`
-	Base       string          `xml:"base,attr"`
-	Attributes []*XSDAttribute `xml:"attribute"`
-	Sequence   []XSDElement    `xml:"sequence>element"`
-	Choice     []*XSDElement   `xml:"choice>element"`
+	XMLName        xml.Name        `xml:"extension"`
+	Base           string          `xml:"base,attr"`
+	Attributes     []*XSDAttribute `xml:"attribute"`
+	Sequence       []XSDElement    `xml:"sequence>element"`
+	Choice         []*XSDElement   `xml:"choice>element"`
+	SequenceChoice []*XSDElement   `xml:"sequence>choice>element"`
 }
 
 // XSDAttribute represent an element attribute. Simple elements cannot have


### PR DESCRIPTION
```xsd
<xs:complexType name="myComplexType">
  <xs:complexContent>
    <xs:extension base="myBaseType">
      <xs:sequence>
        <xs:choice>
          <xs:element name="myType" type="xs:string"/>
        </xs:choice>
      </xs:sequence>
    </xs:extension>
  </xs:complexContent>
</xs:complexType>
```
must result in a struct field `MyType` of type `string`.