### PR TITLE
Avoid XML name conflicts in XML tags between field tag and struct's XMLName field

### DIFF
--- a/fixtures/epcis/epcisquery.src
+++ b/fixtures/epcis/epcisquery.src
@@ -226,10 +226,14 @@ type EPCISDocumentType struct {
 }
 
 type EPCISDocumentExtensionType struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis:xsd:1 extension"`
+
 	Items []string `xml:",any" json:"items,omitempty"`
 }
 
 type EPCISHeaderType struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis:xsd:1 EPCISHeader"`
+
 	StandardBusinessDocumentHeader *StandardBusinessDocumentHeader `xml:"StandardBusinessDocumentHeader,omitempty" json:"StandardBusinessDocumentHeader,omitempty"`
 
 	Extension *EPCISHeaderExtensionType `xml:"extension,omitempty" json:"extension,omitempty"`
@@ -238,30 +242,42 @@ type EPCISHeaderType struct {
 }
 
 type EPCISHeaderExtensionType struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis:xsd:1 extension"`
+
 	EPCISMasterData *EPCISMasterDataType `xml:"EPCISMasterData,omitempty" json:"EPCISMasterData,omitempty"`
 
 	Extension *EPCISHeaderExtension2Type `xml:"extension,omitempty" json:"extension,omitempty"`
 }
 
 type EPCISHeaderExtension2Type struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis:xsd:1 extension"`
+
 	Items []string `xml:",any" json:"items,omitempty"`
 }
 
 type EPCISMasterDataType struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis:xsd:1 EPCISMasterData"`
+
 	VocabularyList *VocabularyListType `xml:"VocabularyList,omitempty" json:"VocabularyList,omitempty"`
 
 	Extension *EPCISMasterDataExtensionType `xml:"extension,omitempty" json:"extension,omitempty"`
 }
 
 type EPCISMasterDataExtensionType struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis:xsd:1 extension"`
+
 	Items []string `xml:",any" json:"items,omitempty"`
 }
 
 type VocabularyListType struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis:xsd:1 VocabularyList"`
+
 	Vocabulary []*VocabularyType `xml:"Vocabulary,omitempty" json:"Vocabulary,omitempty"`
 }
 
 type VocabularyType struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis:xsd:1 Vocabulary"`
+
 	VocabularyElementList *VocabularyElementListType `xml:"VocabularyElementList,omitempty" json:"VocabularyElementList,omitempty"`
 
 	Extension *VocabularyExtensionType `xml:"extension,omitempty" json:"extension,omitempty"`
@@ -272,10 +288,14 @@ type VocabularyType struct {
 }
 
 type VocabularyElementListType struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis:xsd:1 VocabularyElementList"`
+
 	VocabularyElement []*VocabularyElementType `xml:"VocabularyElement,omitempty" json:"VocabularyElement,omitempty"`
 }
 
 type VocabularyElementType struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis:xsd:1 VocabularyElement"`
+
 	Attribute []*AttributeType `xml:"attribute,omitempty" json:"attribute,omitempty"`
 
 	Children *IDListType `xml:"children,omitempty" json:"children,omitempty"`
@@ -288,24 +308,34 @@ type VocabularyElementType struct {
 }
 
 type AttributeType struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis:xsd:1 attribute"`
+
 	AnyType
 
 	Id AnyURI `xml:"id,attr,omitempty" json:"id,omitempty"`
 }
 
 type IDListType struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis:xsd:1 children"`
+
 	Id []AnyURI `xml:"id,omitempty" json:"id,omitempty"`
 }
 
 type VocabularyExtensionType struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis:xsd:1 extension"`
+
 	Items []string `xml:",any" json:"items,omitempty"`
 }
 
 type VocabularyElementExtensionType struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis:xsd:1 extension"`
+
 	Items []string `xml:",any" json:"items,omitempty"`
 }
 
 type EPCISBodyType struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis:xsd:1 EPCISBody"`
+
 	EventList *EventListType `xml:"EventList,omitempty" json:"EventList,omitempty"`
 
 	Extension *EPCISBodyExtensionType `xml:"extension,omitempty" json:"extension,omitempty"`
@@ -314,10 +344,14 @@ type EPCISBodyType struct {
 }
 
 type EPCISBodyExtensionType struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis:xsd:1 extension"`
+
 	Items []string `xml:",any" json:"items,omitempty"`
 }
 
 type EventListType struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis:xsd:1 EventList"`
+
 	ObjectEvent []*ObjectEventType `xml:"ObjectEvent,omitempty" json:"ObjectEvent,omitempty"`
 
 	AggregationEvent []*AggregationEventType `xml:"AggregationEvent,omitempty" json:"AggregationEvent,omitempty"`
@@ -330,12 +364,16 @@ type EventListType struct {
 }
 
 type EPCISEventListExtensionType struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis:xsd:1 extension"`
+
 	TransformationEvent *TransformationEventType `xml:"TransformationEvent,omitempty" json:"TransformationEvent,omitempty"`
 
 	Extension *EPCISEventListExtension2Type `xml:"extension,omitempty" json:"extension,omitempty"`
 }
 
 type EPCISEventListExtension2Type struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis:xsd:1 extension"`
+
 	Items []string `xml:",any" json:"items,omitempty"`
 }
 
@@ -344,6 +382,8 @@ type EPCListType struct {
 }
 
 type QuantityElementType struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis:xsd:1 quantityElement"`
+
 	EpcClass *EPCClassType `xml:"epcClass,omitempty" json:"epcClass,omitempty"`
 }
 
@@ -352,6 +392,8 @@ type QuantityListType struct {
 }
 
 type ReadPointType struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis:xsd:1 readPoint"`
+
 	Id *ReadPointIDType `xml:"id,omitempty" json:"id,omitempty"`
 
 	Extension *ReadPointExtensionType `xml:"extension,omitempty" json:"extension,omitempty"`
@@ -360,10 +402,14 @@ type ReadPointType struct {
 }
 
 type ReadPointExtensionType struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis:xsd:1 extension"`
+
 	Items []string `xml:",any" json:"items,omitempty"`
 }
 
 type BusinessLocationType struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis:xsd:1 bizLocation"`
+
 	Id *BusinessLocationIDType `xml:"id,omitempty" json:"id,omitempty"`
 
 	Extension *BusinessLocationExtensionType `xml:"extension,omitempty" json:"extension,omitempty"`
@@ -372,16 +418,22 @@ type BusinessLocationType struct {
 }
 
 type BusinessLocationExtensionType struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis:xsd:1 extension"`
+
 	Items []string `xml:",any" json:"items,omitempty"`
 }
 
 type BusinessTransactionType struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis:xsd:1 bizTransaction"`
+
 	Value *BusinessTransactionIDType `xml:",chardata" json:"-,"`
 
 	Type *BusinessTransactionTypeIDType `xml:"type,attr,omitempty" json:"type,omitempty"`
 }
 
 type BusinessTransactionListType struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis:xsd:1 bizTransactionList"`
+
 	BizTransaction []*BusinessTransactionType `xml:"bizTransaction,omitempty" json:"bizTransaction,omitempty"`
 }
 
@@ -392,28 +444,40 @@ type SourceDestType struct {
 }
 
 type SourceListType struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis:xsd:1 sourceList"`
+
 	Source []*SourceDestType `xml:"source,omitempty" json:"source,omitempty"`
 }
 
 type DestinationListType struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis:xsd:1 destinationList"`
+
 	Destination []*SourceDestType `xml:"destination,omitempty" json:"destination,omitempty"`
 }
 
 type ILMDType struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis:xsd:1 ilmd"`
+
 	Extension *ILMDExtensionType `xml:"extension,omitempty" json:"extension,omitempty"`
 
 	Items []string `xml:",any" json:"items,omitempty"`
 }
 
 type ILMDExtensionType struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis:xsd:1 extension"`
+
 	Items []string `xml:",any" json:"items,omitempty"`
 }
 
 type CorrectiveEventIDsType struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis:xsd:1 correctiveEventIDs"`
+
 	CorrectiveEventID []*EventIDType `xml:"correctiveEventID,omitempty" json:"correctiveEventID,omitempty"`
 }
 
 type ErrorDeclarationType struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis:xsd:1 errorDeclaration"`
+
 	DeclarationTime soap.XSDDateTime `xml:"declarationTime,omitempty" json:"declarationTime,omitempty"`
 
 	Reason *ErrorReasonIDType `xml:"reason,omitempty" json:"reason,omitempty"`
@@ -426,6 +490,8 @@ type ErrorDeclarationType struct {
 }
 
 type ErrorDeclarationExtensionType struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis:xsd:1 extension"`
+
 	Items []string `xml:",any" json:"items,omitempty"`
 }
 
@@ -440,6 +506,8 @@ type EPCISEventType struct {
 }
 
 type EPCISEventExtensionType struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis:xsd:1 baseExtension"`
+
 	EventID *EventIDType `xml:"eventID,omitempty" json:"eventID,omitempty"`
 
 	ErrorDeclaration *ErrorDeclarationType `xml:"errorDeclaration,omitempty" json:"errorDeclaration,omitempty"`
@@ -448,10 +516,14 @@ type EPCISEventExtensionType struct {
 }
 
 type EPCISEventExtension2Type struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis:xsd:1 extension"`
+
 	Items []string `xml:",any" json:"items,omitempty"`
 }
 
 type ObjectEventType struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis:xsd:1 ObjectEvent"`
+
 	*EPCISEventType
 
 	EpcList *EPCListType `xml:"epcList,omitempty" json:"epcList,omitempty"`
@@ -472,6 +544,8 @@ type ObjectEventType struct {
 }
 
 type ObjectEventExtensionType struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis:xsd:1 extension"`
+
 	QuantityList *QuantityListType `xml:"quantityList,omitempty" json:"quantityList,omitempty"`
 
 	SourceList *SourceListType `xml:"sourceList,omitempty" json:"sourceList,omitempty"`
@@ -484,10 +558,14 @@ type ObjectEventExtensionType struct {
 }
 
 type ObjectEventExtension2Type struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis:xsd:1 extension"`
+
 	Items []string `xml:",any" json:"items,omitempty"`
 }
 
 type AggregationEventType struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis:xsd:1 AggregationEvent"`
+
 	*EPCISEventType
 
 	ParentID *ParentIDType `xml:"parentID,omitempty" json:"parentID,omitempty"`
@@ -510,6 +588,8 @@ type AggregationEventType struct {
 }
 
 type AggregationEventExtensionType struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis:xsd:1 extension"`
+
 	ChildQuantityList *QuantityListType `xml:"childQuantityList,omitempty" json:"childQuantityList,omitempty"`
 
 	SourceList *SourceListType `xml:"sourceList,omitempty" json:"sourceList,omitempty"`
@@ -520,10 +600,14 @@ type AggregationEventExtensionType struct {
 }
 
 type AggregationEventExtension2Type struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis:xsd:1 extension"`
+
 	Items []string `xml:",any" json:"items,omitempty"`
 }
 
 type QuantityEventType struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis:xsd:1 QuantityEvent"`
+
 	*EPCISEventType
 
 	EpcClass *EPCClassType `xml:"epcClass,omitempty" json:"epcClass,omitempty"`
@@ -544,10 +628,14 @@ type QuantityEventType struct {
 }
 
 type QuantityEventExtensionType struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis:xsd:1 extension"`
+
 	Items []string `xml:",any" json:"items,omitempty"`
 }
 
 type TransactionEventType struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis:xsd:1 TransactionEvent"`
+
 	*EPCISEventType
 
 	BizTransactionList *BusinessTransactionListType `xml:"bizTransactionList,omitempty" json:"bizTransactionList,omitempty"`
@@ -570,6 +658,8 @@ type TransactionEventType struct {
 }
 
 type TransactionEventExtensionType struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis:xsd:1 extension"`
+
 	QuantityList *QuantityListType `xml:"quantityList,omitempty" json:"quantityList,omitempty"`
 
 	SourceList *SourceListType `xml:"sourceList,omitempty" json:"sourceList,omitempty"`
@@ -580,10 +670,14 @@ type TransactionEventExtensionType struct {
 }
 
 type TransactionEventExtension2Type struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis:xsd:1 extension"`
+
 	Items []string `xml:",any" json:"items,omitempty"`
 }
 
 type TransformationEventType struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis:xsd:1 TransformationEvent"`
+
 	*EPCISEventType
 
 	InputEPCList *EPCListType `xml:"inputEPCList,omitempty" json:"inputEPCList,omitempty"`
@@ -616,6 +710,8 @@ type TransformationEventType struct {
 }
 
 type TransformationEventExtensionType struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis:xsd:1 extension"`
+
 	Items []string `xml:",any" json:"items,omitempty"`
 }
 
@@ -660,10 +756,14 @@ type EPCISQueryDocumentType struct {
 }
 
 type EPCISQueryDocumentExtensionType struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis-query:xsd:1 extension"`
+
 	Items []string `xml:",any" json:"items,omitempty"`
 }
 
 type EPCISQueryBodyType struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis-query:xsd:1 EPCISBody"`
+
 	GetQueryNames *GetQueryNames `xml:"GetQueryNames,omitempty" json:"GetQueryNames,omitempty"`
 
 	GetQueryNamesResult *GetQueryNamesResult `xml:"GetQueryNamesResult,omitempty" json:"GetQueryNamesResult,omitempty"`
@@ -746,20 +846,18 @@ type Poll struct {
 }
 
 type VoidHolder struct {
-	XMLName xml.Name `xml:"urn:epcglobal:epcis-query:xsd:1 SubscribeResult"`
 }
 
 type EmptyParms struct {
-	XMLName xml.Name `xml:"urn:epcglobal:epcis-query:xsd:1 GetQueryNames"`
 }
 
 type ArrayOfString struct {
-	XMLName xml.Name `xml:"urn:epcglobal:epcis-query:xsd:1 GetQueryNamesResult"`
-
 	Astring []string `xml:"string,omitempty" json:"string,omitempty"`
 }
 
 type SubscriptionControls struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis-query:xsd:1 controls"`
+
 	Schedule *QuerySchedule `xml:"schedule,omitempty" json:"schedule,omitempty"`
 
 	Trigger AnyURI `xml:"trigger,omitempty" json:"trigger,omitempty"`
@@ -774,10 +872,14 @@ type SubscriptionControls struct {
 }
 
 type SubscriptionControlsExtensionType struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis-query:xsd:1 extension"`
+
 	Items []string `xml:",any" json:"items,omitempty"`
 }
 
 type QuerySchedule struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis-query:xsd:1 schedule"`
+
 	Second string `xml:"second,omitempty" json:"second,omitempty"`
 
 	Minute string `xml:"minute,omitempty" json:"minute,omitempty"`
@@ -796,14 +898,20 @@ type QuerySchedule struct {
 }
 
 type QueryScheduleExtensionType struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis-query:xsd:1 extension"`
+
 	Items []string `xml:",any" json:"items,omitempty"`
 }
 
 type QueryParams struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis-query:xsd:1 params"`
+
 	Param []*QueryParam `xml:"param,omitempty" json:"param,omitempty"`
 }
 
 type QueryParam struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis-query:xsd:1 param"`
+
 	Name string `xml:"name,omitempty" json:"name,omitempty"`
 
 	Value AnyType `xml:"value,omitempty" json:"value,omitempty"`
@@ -822,10 +930,14 @@ type QueryResults struct {
 }
 
 type QueryResultsExtensionType struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis-query:xsd:1 extension"`
+
 	Items []string `xml:",any" json:"items,omitempty"`
 }
 
 type QueryResultsBody struct {
+	XMLName xml.Name `xml:"urn:epcglobal:epcis-query:xsd:1 resultsBody"`
+
 	EventList *EventListType `xml:"EventList,omitempty" json:"EventList,omitempty"`
 
 	VocabularyList *VocabularyListType `xml:"VocabularyList,omitempty" json:"VocabularyList,omitempty"`

--- a/gowsdl.go
+++ b/gowsdl.go
@@ -526,15 +526,7 @@ func (g *GoWSDL) findType(message string) string {
 
 // Given a type, check if there's an Element with that type, and return its name.
 func (g *GoWSDL) findNameByType(name string) string {
-	name = stripns(name)
-	for _, schema := range g.wsdl.Types.Schemas {
-		for _, elem := range schema.Elements {
-			if stripns(elem.Type) == name {
-				return elem.Name
-			}
-		}
-	}
-	return name
+	return newTraverser(nil, g.wsdl.Types.Schemas).findNameByType(name)
 }
 
 // TODO(c4milo): Add support for namespaces instead of striping them out

--- a/gowsdl.go
+++ b/gowsdl.go
@@ -524,7 +524,7 @@ func (g *GoWSDL) findType(message string) string {
 	return ""
 }
 
-// Given a type, check if there's SimpleType with that type, and return its name.
+// Given a type, check if there's an Element with that type, and return its name.
 func (g *GoWSDL) findNameByType(name string) string {
 	name = stripns(name)
 	for _, schema := range g.wsdl.Types.Schemas {

--- a/traverser.go
+++ b/traverser.go
@@ -5,19 +5,34 @@ import (
 	"strings"
 )
 
+type traverseMode int32
+
+const (
+	refResolution traverseMode = iota
+	findNameByType
+)
+
 type traverser struct {
 	c   *XSDSchema
 	all []*XSDSchema
+	tm  traverseMode
+	// fields used by findNameByType mode
+	typeName             string
+	foundElmName         string
+	conflictingTypeUsage bool
 }
 
 func newTraverser(c *XSDSchema, all []*XSDSchema) *traverser {
 	return &traverser{
 		c:   c,
 		all: all,
+		tm:  refResolution, // default traverse mode is refResolution
 	}
 }
 
 func (t *traverser) traverse() {
+	t.tm = refResolution
+
 	for _, ct := range t.c.ComplexTypes {
 		t.traverseComplexType(ct)
 	}
@@ -29,6 +44,46 @@ func (t *traverser) traverse() {
 	}
 }
 
+// Given a type, check if there is an Element with that type, and return its name.
+// If multiple elements with identical names of the given type are found,
+// the name is returned.
+// If multiple elements with different names of the given type are found,
+// the original type name is returned instead.
+// If no elements are found, the original type name is returned instead.
+func (t *traverser) findNameByType(name string) string {
+	t.initFindNameByType(name)
+
+	// Search for elements of given type
+	for _, schema := range t.all {
+		for _, elm := range schema.Elements {
+			t.traverseElement(elm)
+		}
+		for _, ct := range schema.ComplexTypes {
+			t.traverseComplexType(ct)
+		}
+		for _, st := range schema.SimpleType {
+			t.traverseSimpleType(st)
+		}
+	}
+
+	// Return found element name if given type is used only once
+	if len(t.foundElmName) > 0 && !t.conflictingTypeUsage {
+		return t.foundElmName
+	}
+
+	// Return original type name
+	// No element found or conflicting element names found
+	return t.typeName
+}
+
+func (t *traverser) initFindNameByType(name string) {
+	// Initialize fields for processing
+	t.tm = findNameByType
+	t.typeName = stripns(name)
+	t.foundElmName = ""
+	t.conflictingTypeUsage = false
+}
+
 func (t *traverser) traverseElements(ct []*XSDElement) {
 	for _, elm := range ct {
 		t.traverseElement(elm)
@@ -36,11 +91,35 @@ func (t *traverser) traverseElements(ct []*XSDElement) {
 }
 
 func (t *traverser) traverseElement(elm *XSDElement) {
+	t.findElmName(elm)
+
 	if elm.ComplexType != nil {
 		t.traverseComplexType(elm.ComplexType)
 	}
 	if elm.SimpleType != nil {
 		t.traverseSimpleType(elm.SimpleType)
+	}
+}
+
+func (t *traverser) findElmName(elm *XSDElement) {
+	// Check if we are called by findNameByType
+	if t.tm != findNameByType {
+		return
+	}
+
+	// Conflicting type usage already detected -> no need to search any further
+	if t.conflictingTypeUsage {
+		return
+	}
+
+	if stripns(elm.Type) == t.typeName {
+		if len(t.foundElmName) == 0 {
+			// First time usage t.typeName
+			t.foundElmName = elm.Name
+		} else if t.foundElmName != elm.Name {
+			// Duplicate use of t.typeName with different element names
+			t.conflictingTypeUsage = true
+		}
 	}
 }
 
@@ -54,6 +133,9 @@ func (t *traverser) traverseComplexType(ct *XSDComplexType) {
 	t.traverseElements(ct.All)
 	t.traverseAttributes(ct.Attributes)
 	t.traverseAttributes(ct.ComplexContent.Extension.Attributes)
+	t.traverseElements(ct.ComplexContent.Extension.Sequence)
+	t.traverseElements(ct.ComplexContent.Extension.Choice)
+	t.traverseElements(ct.ComplexContent.Extension.SequenceChoice)
 	t.traverseAttributes(ct.SimpleContent.Extension.Attributes)
 }
 
@@ -64,6 +146,11 @@ func (t *traverser) traverseAttributes(attrs []*XSDAttribute) {
 }
 
 func (t *traverser) traverseAttribute(attr *XSDAttribute) {
+	// Check if we are in ref resolution mode
+	if t.tm != refResolution {
+		return
+	}
+
 	if attr.Ref != "" {
 		refAttr := t.getGlobalAttribute(attr.Ref)
 		if refAttr != nil && refAttr.Ref == "" {

--- a/types_tmpl.go
+++ b/types_tmpl.go
@@ -148,7 +148,7 @@ var typesTmpl = `
 		{{else}}
 			type {{$name}} struct {
 				{{$typ := findNameByType .Name}}
-				{{if ne $name $typ}}
+				{{if ne .Name $type}}
 					XMLName xml.Name ` + "`xml:\"{{$targetNamespace}} {{$typ}}\"`" + `
 				{{end}}
 

--- a/xsd.go
+++ b/xsd.go
@@ -191,7 +191,7 @@ type XSDExtension struct {
 	XMLName    xml.Name        `xml:"extension"`
 	Base       string          `xml:"base,attr"`
 	Attributes []*XSDAttribute `xml:"attribute"`
-	Sequence   []XSDElement    `xml:"sequence>element"`
+	Sequence   []*XSDElement   `xml:"sequence>element"`
 	Choice     []*XSDElement   `xml:"choice>element"`
 }
 


### PR DESCRIPTION
This fixes #224.

The problem was initially addressed with PR #109 (issue #73) in commit dd8f1cae4f65c55c7ddca89a21925dd9d85ad14e. However that commit does not address all possible name mismatch scenarios.

If multiple elements with different names are of the same complexType, the existing logic arbitrarily takes the first element's name for the struct's XMLName field tag. All other elements with different names then conflict with that tag.

Errors would typically look like these:
- `"xml: name \"order\" in tag of example.AckType.Order conflicts with name \"orderType\" in *example.OrderType.XMLName"`
- `"expected element type <historyType> but have <history>"`

This PR proposes two changes:
1. A modification to the original commit dd8f1cae4f65c55c7ddca89a21925dd9d85ad14e to avoid generating potentially conflicting XML name tags. This is probably more of an unintended bug because the author worked with upper case type names in the first place and therefore would not notice this problem.
2. A much more generic implementation by enhancing the traverser to actually find and detect conflicting names and omit the respective XMLName struct fields with tags in complexTypes.

Both changes are required to solve all conflicting cases.

Test fixtures are adapted and verified for this change.