### PR TITLE
Handle empty strings in enums

### DIFF
--- a/fixtures/chromedata.wsdl
+++ b/fixtures/chromedata.wsdl
@@ -200,6 +200,7 @@
 
             <simpleType name="DriveTrain">
                 <restriction base="string">
+                    <enumeration value="" />
                     <enumeration value="Front Wheel Drive" />
                     <enumeration value="Rear Wheel Drive" />
                     <enumeration value="All Wheel Drive" />

--- a/gowsdl.go
+++ b/gowsdl.go
@@ -587,6 +587,9 @@ func makePublic(identifier string) string {
 	if isBasicType(identifier) {
 		return identifier
 	}
+	if identifier == "" {
+		return "EmptyString"
+	}
 	field := []rune(identifier)
 	if len(field) == 0 {
 		return identifier

--- a/gowsdl_test.go
+++ b/gowsdl_test.go
@@ -245,8 +245,7 @@ func TestEnumerationsGeneratedCorrectly(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-
-		re := regexp.MustCompile(varName + " " + typeName + " = \"([^\"]+)\"")
+		re := regexp.MustCompile(varName + " " + typeName + " = \"([^\"]*)\"")
 		matches := re.FindStringSubmatch(string(resp["types"]))
 
 		if len(matches) != 2 {
@@ -256,6 +255,7 @@ func TestEnumerationsGeneratedCorrectly(t *testing.T) {
 		}
 	}
 	enumStringTest(t, "chromedata.wsdl", "DriveTrainFrontWheelDrive", "DriveTrain", "Front Wheel Drive")
+	enumStringTest(t, "chromedata.wsdl", "DriveTrainEmptyString", "DriveTrain", "")
 	enumStringTest(t, "vboxweb.wsdl", "SettingsVersionV1_14", "SettingsVersion", "v1_14")
 
 }


### PR DESCRIPTION
This PR fixes #236 

In short, this XML:

```xml
<simpleType name="DriveTrain">
    <restriction base="string">
        <enumeration value="" />
        <enumeration value="Front Wheel Drive" />
        <enumeration value="Rear Wheel Drive" />
        <enumeration value="All Wheel Drive" />
        <enumeration value="Four Wheel Drive" />
    </restriction>
</simpleType>
```

Will generate the following broken go code:

<img width="546" alt="Screenshot 2022-03-15 at 21 33 26" src="https://user-images.githubusercontent.com/35707048/158477080-66412474-e71a-4c13-914e-6cc081ecfbc3.png">

This PR changes the implementation so it is generated like so:

<img width="518" alt="Screenshot 2022-03-15 at 21 33 47" src="https://user-images.githubusercontent.com/35707048/158477891-7177bcc3-71ae-46e1-a39d-d63bf3d2a58d.png">

