### PR TITLE
adjust SOAP Header handling to not include headers/header elements

### DIFF
--- a/soap/soap.go
+++ b/soap/soap.go
@@ -29,18 +29,12 @@ type SOAPEnvelopeResponse struct {
 }
 
 type SOAPEnvelope struct {
-	XMLName xml.Name `xml:"soap:Envelope"`
-	XmlNS   string   `xml:"xmlns:soap,attr"`
-
-	Header *SOAPHeader
-	Body   SOAPBody
+	XMLName xml.Name      `xml:"soap:Envelope"`
+	XmlNS   string        `xml:"xmlns:soap,attr"`
+	Headers []interface{} `xml:"soap:Header"`
+	Body    SOAPBody
 }
 
-type SOAPHeader struct {
-	XMLName xml.Name `xml:"soap:Header"`
-
-	Headers []interface{}
-}
 type SOAPHeaderResponse struct {
 	XMLName xml.Name `xml:"Header"`
 
@@ -418,11 +412,7 @@ func (s *Client) call(ctx context.Context, soapAction string, request, response 
 		XmlNS: XmlNsSoapEnv,
 	}
 
-	if s.headers != nil && len(s.headers) > 0 {
-		envelope.Header = &SOAPHeader{
-			Headers: s.headers,
-		}
-	}
+	envelope.Headers = s.headers
 
 	envelope.Body.Content = request
 	buffer := new(bytes.Buffer)
@@ -514,7 +504,7 @@ func (s *Client) call(ctx context.Context, soapAction string, request, response 
 	}
 
 	var mmaBoundary string
-	if s.opts.mma{
+	if s.opts.mma {
 		mmaBoundary, err = getMmaHeader(res.Header.Get("Content-Type"))
 		if err != nil {
 			return err


### PR DESCRIPTION
HI,

using headers in SOAP will result in XML elements like:
---
<soap:Header>
  <Headers>
 ...
---

which is not valid.
This PR will fix this issue

Thanks,
Kristian