### PR TITLE
Updated Install Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,10 @@ Generates Go code from a WSDL file.
 
 ### Install
 
-* [Download binary release](https://github.com/hooklift/gowsdl/releases)
-* Download and build locally: `go get github.com/hooklift/gowsdl/...`
+* [Download release](https://github.com/hooklift/gowsdl/releases)
+* Download and build locally
+    * 1.15: `go get github.com/hooklift/gowsdl/...`
+    * 1.20: `go install github.com/hooklift/gowsdl/cmd/gowsdl@latest`
 * Install from Homebrew: `brew install gowsdl`
 
 ### Goals


### PR DESCRIPTION
## Documentation Changed

* Updated the README with Install instructions for Go version 1.20.
* Removed the word "binary" from the "Download binary releases" link, since there are no binaries.
