### PR TITLE
Enumeration duplicates with special characters like "+"

### DIFF
--- a/gowsdl.go
+++ b/gowsdl.go
@@ -456,6 +456,14 @@ var reservedWordsInAttr = map[string]string{
 	"string":      "astring",
 }
 
+var specialCharacterMapping = map[string]string{
+	"+": "Plus",
+	"-": "Minus",
+	"@": "At",
+	"/": "Slash",
+	"$": "Dollar",
+}
+
 // Replaces Go reserved keywords to avoid compilation issues
 func replaceReservedWords(identifier string) string {
 	value := reservedWords[identifier]
@@ -486,7 +494,9 @@ func normalize(value string) string {
 		return -1
 	}
 
-	value = strings.ReplaceAll(value, "+", "Plus")
+	for k, v := range specialCharacterMapping {
+		value = strings.ReplaceAll(value, k, v)
+	}
 
 	return strings.Map(mapping, value)
 }

--- a/gowsdl.go
+++ b/gowsdl.go
@@ -486,6 +486,8 @@ func normalize(value string) string {
 		return -1
 	}
 
+	value = strings.ReplaceAll(value, "+", "Plus")
+
 	return strings.Map(mapping, value)
 }
 

--- a/gowsdl.go
+++ b/gowsdl.go
@@ -458,10 +458,7 @@ var reservedWordsInAttr = map[string]string{
 
 var specialCharacterMapping = map[string]string{
 	"+": "Plus",
-	"-": "Minus",
 	"@": "At",
-	"/": "Slash",
-	"$": "Dollar",
 }
 
 // Replaces Go reserved keywords to avoid compilation issues
@@ -484,8 +481,12 @@ func replaceAttrReservedWords(identifier string) string {
 
 // Normalizes value to be used as a valid Go identifier, avoiding compilation issues
 func normalize(value string) string {
+	for k, v := range specialCharacterMapping {
+		value = strings.ReplaceAll(value, k, v)
+	}
+
 	mapping := func(r rune) rune {
-		if r == '.' {
+		if r == '.' || r == '-' {
 			return '_'
 		}
 		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' {
@@ -494,15 +495,11 @@ func normalize(value string) string {
 		return -1
 	}
 
-	for k, v := range specialCharacterMapping {
-		value = strings.ReplaceAll(value, k, v)
-	}
-
 	return strings.Map(mapping, value)
 }
 
 func goString(s string) string {
-	return strings.Replace(s, "\"", "\\\"", -1)
+	return strings.ReplaceAll(s, "\"", "\\\"")
 }
 
 var xsd2GoTypes = map[string]string{


### PR DESCRIPTION
I am having the following enumeration

```xml
	<xs:simpleType name="UebertragungsverfahrenType">
		<xs:restriction base="xs:string">
			<xs:enumeration value="ADSL2AM"/>
			<xs:enumeration value="ADSL2+AM"/>
		</xs:restriction>
	</xs:simpleType>
```

Currently `normalize` just throws array all illegal characters in an identifier, leading to a duplicate const value and a compilation error.

This PR introduces a specialCharacterMapping, which adds a `Plus` for the `+` in the name