### PR TITLE
add GetHeaders

### DIFF
--- a/soap/soap.go
+++ b/soap/soap.go
@@ -367,6 +367,11 @@ func (s *Client) AddMIMEMultipartAttachment(attachment MIMEMultipartAttachment) 
 	s.attachments = append(s.attachments, attachment)
 }
 
+// GetHeaders gets envelope headers.
+func (s *Client) GetHeaders() interface{} {
+	return s.headers
+}
+
 // SetHeaders sets envelope headers, overwriting any existing headers.
 // For correct behavior, every header must contain a `XMLName` field.  Refer to #121 for details
 func (s *Client) SetHeaders(headers ...interface{}) {

--- a/soap/soap.go
+++ b/soap/soap.go
@@ -367,8 +367,8 @@ func (s *Client) AddMIMEMultipartAttachment(attachment MIMEMultipartAttachment) 
 	s.attachments = append(s.attachments, attachment)
 }
 
-// GetHeaders gets envelope headers.
-func (s *Client) GetHeaders() interface{} {
+// Headers retrieve envelope headers.
+func (s *Client) Headers() interface{} {
 	return s.headers
 }
 


### PR DESCRIPTION
I know that there is [no getters and setters](https://go.dev/doc/effective_go#Getters) in go, but there is exceptions.

In my opinion we should get rid of the addHeaders and setHeaders and export Headers

Sometimes we really need to get the Headers in the response, especially for eDelivery, where the metada on the headers is needed