### PR TITLE
Don't hide the underlying type

### DIFF
--- a/gowsdl_test.go
+++ b/gowsdl_test.go
@@ -165,7 +165,7 @@ func TestDateTimeType(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected := `type StartDate soap.XSDDateTime`
+	expected := `type StartDate = soap.XSDDateTime`
 
 	if actual != expected {
 		t.Error("got \n" + actual + " want \n" + expected)

--- a/types_tmpl.go
+++ b/types_tmpl.go
@@ -150,7 +150,7 @@ var typesTmpl = `
 				{{else}}
 					type {{$typeName}} interface{}
 				{{end}}
-			
+
 				{{if .Restriction.Enumeration}}
 				const (
 					{{with .Restriction}}
@@ -164,7 +164,7 @@ var typesTmpl = `
 		{{else}}
 			{{$type := toGoType .Type .Nillable | removePointerFromType}}
 			{{if ne ($typeName) ($type)}}
-				type {{$typeName}} {{$type}}
+				type {{$typeName}} = {{$type}}
 				{{if eq ($type) ("soap.XSDDateTime")}}
 					func (xdt {{$typeName}}) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 						return soap.XSDDateTime(xdt).MarshalXML(e, start)


### PR DESCRIPTION
This pull request avoids the hiding of the underlying type and its methods. A use case would be to access the methods of `soap.XSDDateTime`. Consider the following code:

```
type StartDate soap.XSDDateTime

type FooBar struct {
    Date *StartDate
}

...

fooBar := FooBar{}
```

It is not possible to access `foobar.Date.ToGoTime()`. This commit declares the `StartDate` type as follows:

```
type StartDate = soap.XSDDateTime
```
Which allows the complete access to the underlying type.