### PR TITLE
Response Attachment handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build
 dist
 .idea/
 fixtures/epcis/epcisquery_gen.src
+*.exe

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build
 .DS_Store
 dist
 .idea/
+fixtures/epcis/epcisquery_gen.src

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "makefile.configureOnOpen": false
+}

--- a/cmd/gowsdl/main.go
+++ b/cmd/gowsdl/main.go
@@ -119,9 +119,7 @@ func main() {
 
 	pkg := filepath.Join(*dir, *pkg)
 	if *clientStub || *serverStub {
-		if err := os.Mkdir(pkg, 0744); err != nil {
-			log.Fatalln(err)
-		}
+		os.Mkdir(pkg, 0744)
 	}
 
 	if *clientStub {

--- a/fixtures/epcis/epcisquery.src
+++ b/fixtures/epcis/epcisquery.src
@@ -13,14 +13,6 @@ import (
 var _ time.Time
 var _ xml.Name
 
-type AnyType struct {
-	InnerXML string `xml:",innerxml"`
-}
-
-type AnyURI string
-
-type NCName string
-
 type Document struct {
 
 	//
@@ -59,9 +51,11 @@ type Partner struct {
 }
 
 type PartnerIdentification struct {
+	XMLName xml.Name `xml:"http://www.unece.org/cefact/namespaces/StandardBusinessDocumentHeader Identifier"`
+
 	Value string `xml:",chardata" json:"-,"`
 
-	Authority string `xml:"Authority,attr,omitempty" json:"Authority,omitempty"`
+	Authority string `xml:"http://www.unece.org/cefact/namespaces/StandardBusinessDocumentHeader Authority,attr,omitempty" json:"Authority,omitempty"`
 }
 
 type ContactInformation struct {
@@ -96,7 +90,7 @@ type Manifest struct {
 type ManifestItem struct {
 	MimeTypeQualifierCode *MimeTypeQualifier `xml:"MimeTypeQualifierCode,omitempty" json:"MimeTypeQualifierCode,omitempty"`
 
-	UniformResourceIdentifier AnyURI `xml:"UniformResourceIdentifier,omitempty" json:"UniformResourceIdentifier,omitempty"`
+	UniformResourceIdentifier soap.AnyURI `xml:"UniformResourceIdentifier,omitempty" json:"UniformResourceIdentifier,omitempty"`
 
 	Description string `xml:"Description,omitempty" json:"Description,omitempty"`
 
@@ -111,7 +105,7 @@ const (
 	TypeOfServiceTransactionRespondingServiceTransaction TypeOfServiceTransaction = "RespondingServiceTransaction"
 )
 
-type ScopeInformation AnyType
+type ScopeInformation soap.AnyType
 
 type BusinessScope struct {
 	Scope []*Scope `xml:"Scope,omitempty" json:"Scope,omitempty"`
@@ -187,33 +181,33 @@ const (
 	ActionTypeDELETE ActionType = "DELETE"
 )
 
-type ParentIDType AnyURI
+type ParentIDType soap.AnyURI
 
-type BusinessStepIDType AnyURI
+type BusinessStepIDType soap.AnyURI
 
-type DispositionIDType AnyURI
+type DispositionIDType soap.AnyURI
 
-type EPCClassType AnyURI
+type EPCClassType soap.AnyURI
 
 type UOMType string
 
-type ReadPointIDType AnyURI
+type ReadPointIDType soap.AnyURI
 
-type BusinessLocationIDType AnyURI
+type BusinessLocationIDType soap.AnyURI
 
-type BusinessTransactionIDType AnyURI
+type BusinessTransactionIDType soap.AnyURI
 
-type BusinessTransactionTypeIDType AnyURI
+type BusinessTransactionTypeIDType soap.AnyURI
 
-type SourceDestIDType AnyURI
+type SourceDestIDType soap.AnyURI
 
-type SourceDestTypeIDType AnyURI
+type SourceDestTypeIDType soap.AnyURI
 
-type TransformationIDType AnyURI
+type TransformationIDType soap.AnyURI
 
-type EventIDType AnyURI
+type EventIDType soap.AnyURI
 
-type ErrorReasonIDType AnyURI
+type ErrorReasonIDType soap.AnyURI
 
 type EPCISDocument EPCISDocumentType
 
@@ -288,7 +282,7 @@ type VocabularyType struct {
 
 	Items []string `xml:",any" json:"items,omitempty"`
 
-	Type AnyURI `xml:"urn:epcglobal:epcis:xsd:1 type,attr,omitempty" json:"type,omitempty"`
+	Type soap.AnyURI `xml:"urn:epcglobal:epcis:xsd:1 type,attr,omitempty" json:"type,omitempty"`
 }
 
 type VocabularyElementListType struct {
@@ -308,21 +302,21 @@ type VocabularyElementType struct {
 
 	Items []string `xml:",any" json:"items,omitempty"`
 
-	Id AnyURI `xml:"urn:epcglobal:epcis:xsd:1 id,attr,omitempty" json:"id,omitempty"`
+	Id soap.AnyURI `xml:"urn:epcglobal:epcis:xsd:1 id,attr,omitempty" json:"id,omitempty"`
 }
 
 type AttributeType struct {
 	XMLName xml.Name `xml:"urn:epcglobal:epcis:xsd:1 attribute"`
 
-	AnyType
+	soap.AnyType
 
-	Id AnyURI `xml:"urn:epcglobal:epcis:xsd:1 id,attr,omitempty" json:"id,omitempty"`
+	Id soap.AnyURI `xml:"urn:epcglobal:epcis:xsd:1 id,attr,omitempty" json:"id,omitempty"`
 }
 
 type IDListType struct {
 	XMLName xml.Name `xml:"urn:epcglobal:epcis:xsd:1 children"`
 
-	Id []AnyURI `xml:"id,omitempty" json:"id,omitempty"`
+	Id []soap.AnyURI `xml:"id,omitempty" json:"id,omitempty"`
 }
 
 type VocabularyExtensionType struct {
@@ -719,7 +713,7 @@ type TransformationEventExtensionType struct {
 	Items []string `xml:",any" json:"items,omitempty"`
 }
 
-type ImplementationExceptionSeverity NCName
+type ImplementationExceptionSeverity soap.NCName
 
 const (
 	ImplementationExceptionSeverityERROR ImplementationExceptionSeverity = "ERROR"
@@ -828,7 +822,7 @@ type Subscribe struct {
 
 	Params *QueryParams `xml:"params,omitempty" json:"params,omitempty"`
 
-	Dest AnyURI `xml:"dest,omitempty" json:"dest,omitempty"`
+	Dest soap.AnyURI `xml:"dest,omitempty" json:"dest,omitempty"`
 
 	Controls *SubscriptionControls `xml:"controls,omitempty" json:"controls,omitempty"`
 
@@ -864,7 +858,7 @@ type SubscriptionControls struct {
 
 	Schedule *QuerySchedule `xml:"schedule,omitempty" json:"schedule,omitempty"`
 
-	Trigger AnyURI `xml:"trigger,omitempty" json:"trigger,omitempty"`
+	Trigger soap.AnyURI `xml:"trigger,omitempty" json:"trigger,omitempty"`
 
 	InitialRecordTime soap.XSDDateTime `xml:"initialRecordTime,omitempty" json:"initialRecordTime,omitempty"`
 
@@ -918,7 +912,7 @@ type QueryParam struct {
 
 	Name string `xml:"name,omitempty" json:"name,omitempty"`
 
-	Value AnyType `xml:"value,omitempty" json:"value,omitempty"`
+	Value soap.AnyType `xml:"value,omitempty" json:"value,omitempty"`
 }
 
 type QueryResults struct {

--- a/gowsdl.go
+++ b/gowsdl.go
@@ -10,7 +10,7 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -85,7 +85,7 @@ func downloadFile(url string, ignoreTLS bool) ([]byte, error) {
 		return nil, fmt.Errorf("Received response code %d", resp.StatusCode)
 	}
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -192,7 +192,7 @@ func (g *GoWSDL) Start() (map[string][]byte, error) {
 func (g *GoWSDL) fetchFile(loc *Location) (data []byte, err error) {
 	if loc.f != "" {
 		log.Println("Reading", "file", loc.f)
-		data, err = ioutil.ReadFile(loc.f)
+		data, err = os.ReadFile(loc.f)
 	} else {
 		log.Println("Downloading", "file", loc.u.String())
 		data, err = downloadFile(loc.u.String(), g.ignoreTLS)

--- a/gowsdl.go
+++ b/gowsdl.go
@@ -331,6 +331,7 @@ func (g *GoWSDL) genOperations() ([]byte, error) {
 		"findType":             g.findType,
 		"findSOAPAction":       g.findSOAPAction,
 		"findServiceAddress":   g.findServiceAddress,
+		"responseAttachments":  g.responseAttachments,
 	}
 
 	data := new(bytes.Buffer)
@@ -646,6 +647,25 @@ func (g *GoWSDL) findServiceAddress(name string) string {
 		}
 	}
 	return ""
+}
+
+// Finds parts of the specified response message that may be returned as an attachment
+// Parts whose name ends with the '-attachment' suffix are marked as response attachments
+func (g *GoWSDL) responseAttachments(message string) []*WSDLPart {
+	message = stripns(message)
+	attachmentParts := make([]*WSDLPart, 0)
+	for _, msg := range g.wsdl.Messages {
+		if msg.Name != message {
+			continue
+		}
+
+		for _, part := range msg.Parts {
+			if strings.HasSuffix(part.Name, "-attachment") {
+				attachmentParts = append(attachmentParts, part)
+			}
+		}
+	}
+	return attachmentParts
 }
 
 // TODO(c4milo): Add namespace support instead of stripping it

--- a/gowsdl.go
+++ b/gowsdl.go
@@ -32,6 +32,7 @@ type GoWSDL struct {
 	rawWSDL               []byte
 	pkg                   string
 	ignoreTLS             bool
+	unqualifiedAttrs      bool
 	makePublicFn          func(string) string
 	wsdl                  *WSDL
 	resolvedXSDExternals  map[string]bool
@@ -47,6 +48,10 @@ func (g *GoWSDL) setNS(ns string) string {
 
 // Method setNS returns the currently active XML namespace.
 func (g *GoWSDL) getNS() string {
+	if g.unqualifiedAttrs {
+		return ""
+	}
+
 	return g.currentNamespace
 }
 
@@ -94,7 +99,7 @@ func downloadFile(url string, ignoreTLS bool) ([]byte, error) {
 }
 
 // NewGoWSDL initializes WSDL generator.
-func NewGoWSDL(file, pkg string, ignoreTLS bool, exportAllTypes bool) (*GoWSDL, error) {
+func NewGoWSDL(file, pkg string, ignoreTLS bool, exportAllTypes bool, unqualifiedAttrs bool) (*GoWSDL, error) {
 	file = strings.TrimSpace(file)
 	if file == "" {
 		return nil, errors.New("WSDL file is required to generate Go proxy")
@@ -115,10 +120,11 @@ func NewGoWSDL(file, pkg string, ignoreTLS bool, exportAllTypes bool) (*GoWSDL, 
 	}
 
 	return &GoWSDL{
-		loc:          r,
-		pkg:          pkg,
-		ignoreTLS:    ignoreTLS,
-		makePublicFn: makePublicFn,
+		loc:              r,
+		pkg:              pkg,
+		ignoreTLS:        ignoreTLS,
+		makePublicFn:     makePublicFn,
+		unqualifiedAttrs: unqualifiedAttrs,
 	}, nil
 }
 
@@ -524,9 +530,9 @@ var xsd2GoTypes = map[string]string{
 	"unsignedshort":      "uint16",
 	"unsignedbyte":       "byte",
 	"unsignedlong":       "uint64",
-	"anytype":            "AnyType",
-	"ncname":             "NCName",
-	"anyuri":             "AnyURI",
+	"anytype":            "soap.AnyType",
+	"ncname":             "soap.NCName",
+	"anyuri":             "soap.AnyURI",
 }
 
 func removeNS(xsdType string) string {

--- a/gowsdl_test.go
+++ b/gowsdl_test.go
@@ -13,7 +13,6 @@ import (
 	"go/parser"
 	"go/printer"
 	"go/token"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -23,7 +22,7 @@ import (
 )
 
 func TestElementGenerationDoesntCommentOutStructProperty(t *testing.T) {
-	g, err := NewGoWSDL("fixtures/test.wsdl", "myservice", false, true)
+	g, err := NewGoWSDL("fixtures/test.wsdl", "myservice", false, true, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -40,7 +39,7 @@ func TestElementGenerationDoesntCommentOutStructProperty(t *testing.T) {
 }
 
 func TestComplexTypeWithInlineSimpleType(t *testing.T) {
-	g, err := NewGoWSDL("fixtures/test.wsdl", "myservice", false, true)
+	g, err := NewGoWSDL("fixtures/test.wsdl", "myservice", false, true, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -65,7 +64,7 @@ func TestComplexTypeWithInlineSimpleType(t *testing.T) {
 }
 
 func TestAttributeRef(t *testing.T) {
-	g, err := NewGoWSDL("fixtures/test.wsdl", "myservice", false, true)
+	g, err := NewGoWSDL("fixtures/test.wsdl", "myservice", false, true, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -97,7 +96,7 @@ func TestAttributeRef(t *testing.T) {
 }
 
 func TestElementWithLocalSimpleType(t *testing.T) {
-	g, err := NewGoWSDL("fixtures/test.wsdl", "myservice", false, true)
+	g, err := NewGoWSDL("fixtures/test.wsdl", "myservice", false, true, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -148,7 +147,7 @@ func TestElementWithLocalSimpleType(t *testing.T) {
 }
 
 func TestDateTimeType(t *testing.T) {
-	g, err := NewGoWSDL("fixtures/test.wsdl", "myservice", false, true)
+	g, err := NewGoWSDL("fixtures/test.wsdl", "myservice", false, true, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -209,7 +208,7 @@ func TestVboxGeneratesWithoutSyntaxErrors(t *testing.T) {
 	}
 
 	for _, file := range files {
-		g, err := NewGoWSDL(file, "myservice", false, true)
+		g, err := NewGoWSDL(file, "myservice", false, true, false)
 		if err != nil {
 			t.Error(err)
 		}
@@ -236,7 +235,7 @@ func TestVboxGeneratesWithoutSyntaxErrors(t *testing.T) {
 
 func TestEnumerationsGeneratedCorrectly(t *testing.T) {
 	enumStringTest := func(t *testing.T, fixtureWsdl string, varName string, typeName string, enumString string) {
-		g, err := NewGoWSDL("fixtures/"+fixtureWsdl, "myservice", false, true)
+		g, err := NewGoWSDL("fixtures/"+fixtureWsdl, "myservice", false, true, false)
 		if err != nil {
 			t.Error(err)
 		}
@@ -261,7 +260,7 @@ func TestEnumerationsGeneratedCorrectly(t *testing.T) {
 }
 
 func TestComplexTypeGeneratedCorrectly(t *testing.T) {
-	g, err := NewGoWSDL("fixtures/workday-time-min.wsdl", "myservice", false, true)
+	g, err := NewGoWSDL("fixtures/workday-time-min.wsdl", "myservice", false, true, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -288,7 +287,7 @@ func TestEPCISWSDL(t *testing.T) {
 	log.SetFlags(0)
 	log.SetOutput(os.Stdout)
 
-	g, err := NewGoWSDL("./fixtures/epcis/EPCglobal-epcis-query-1_2.wsdl", "myservice", true, true)
+	g, err := NewGoWSDL("./fixtures/epcis/EPCglobal-epcis-query-1_2.wsdl", "myservice", true, true, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -308,7 +307,7 @@ func TestEPCISWSDL(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expectedBytes, err := ioutil.ReadFile("./fixtures/epcis/epcisquery.src")
+	expectedBytes, err := os.ReadFile("./fixtures/epcis/epcisquery.src")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -316,7 +315,7 @@ func TestEPCISWSDL(t *testing.T) {
 	actual := string(source)
 	expected := string(expectedBytes)
 	if actual != expected {
-		_ = ioutil.WriteFile("./fixtures/epcis/epcisquery_gen.src", source, 0664)
+		_ = os.WriteFile("./fixtures/epcis/epcisquery_gen.src", source, 0664)
 		t.Error("got source ./fixtures/epcis/epcisquery_gen.src but expected ./fixtures/epcis/epcisquery.src")
 	}
 }

--- a/header_tmpl.go
+++ b/header_tmpl.go
@@ -24,12 +24,4 @@ import (
 var _ time.Time
 var _ xml.Name
 
-type AnyType struct {
-	InnerXML string ` + "`" + `xml:",innerxml"` + "`" + `
-}
-
-type AnyURI string
-
-type NCName string
-
 `

--- a/operations_tmpl.go
+++ b/operations_tmpl.go
@@ -24,9 +24,9 @@ var opsTmpl = `
 			// {{range .Faults}}
 			//   - {{.Name}} {{.Doc}}{{end}}{{end}}
 			{{if ne .Doc ""}}/* {{.Doc}} */{{end}}
-			{{makePublic .Name | replaceReservedWords}} ({{if ne $requestType ""}}request *{{$requestType}}{{end}}) ({{if ne $responseType ""}}*{{$responseType}}, {{end}}{{if gt $attachments 0}}*[]soap.MIMEMultipartAttachment, {{end}}error)
+			{{makePublic .Name | replaceReservedWords}} ({{if ne $requestType ""}}request *{{$requestType}}{{end}}) ({{if ne $responseType ""}}*{{$responseType}}, {{end}}{{if gt $attachments 0}}[]soap.MIMEMultipartAttachment, {{end}}error)
 			{{/*end*/}}
-			{{makePublic .Name | replaceReservedWords}}Context (ctx context.Context, {{if ne $requestType ""}}request *{{$requestType}}{{end}}) ({{if ne $responseType ""}}*{{$responseType}}, {{end}}{{if gt $attachments 0}}*[]soap.MIMEMultipartAttachment, {{end}}error)
+			{{makePublic .Name | replaceReservedWords}}Context (ctx context.Context, {{if ne $requestType ""}}request *{{$requestType}}{{end}}) ({{if ne $responseType ""}}*{{$responseType}}, {{end}}{{if gt $attachments 0}}[]soap.MIMEMultipartAttachment, {{end}}error)
 			{{/*end*/}}
 		{{end}}
 	}
@@ -49,18 +49,17 @@ var opsTmpl = `
 		{{$attachments := len $responseAttachments}}
 
 		{{if gt $attachments 0}}
-			func (service *{{$privateType}}) {{makePublic .Name | replaceReservedWords}}Context (ctx context.Context, {{if ne $requestType ""}}request *{{$requestType}}{{end}}) ({{if ne $responseType ""}}*{{$responseType}}, {{end}}*[]soap.MIMEMultipartAttachment, error) {
+			func (service *{{$privateType}}) {{makePublic .Name | replaceReservedWords}}Context (ctx context.Context, {{if ne $requestType ""}}request *{{$requestType}}{{end}}) ({{if ne $responseType ""}}*{{$responseType}}, {{end}}[]soap.MIMEMultipartAttachment, error) {
 				{{if ne $responseType ""}}response := new({{$responseType}}){{end}}
-				attachments := make([]soap.MIMEMultipartAttachment, 0)
-				err := service.client.CallContextWithAttachmentsAndFaultDetail(ctx, "{{if ne $soapAction ""}}{{$soapAction}}{{else}}''{{end}}", {{if ne $requestType ""}}request{{else}}nil{{end}}, {{if ne $responseType ""}}response{{else}}struct{}{}{{end}}, nil, &attachments)
+				attachments, err := service.client.CallContextWithAttachmentsAndFaultDetail(ctx, "{{if ne $soapAction ""}}{{$soapAction}}{{else}}''{{end}}", {{if ne $requestType ""}}request{{else}}nil{{end}}, {{if ne $responseType ""}}response{{else}}struct{}{}{{end}}, nil)
 				if err != nil {
 					return {{if ne $responseType ""}}nil, {{end}}nil, err
 				}
 
-				return {{if ne $responseType ""}}response, {{end}}&attachments, nil
+				return {{if ne $responseType ""}}response, {{end}}attachments, nil
 			}
 
-			func (service *{{$privateType}}) {{makePublic .Name | replaceReservedWords}} ({{if ne $requestType ""}}request *{{$requestType}}{{end}}) ({{if ne $responseType ""}}*{{$responseType}}, {{end}}*[]soap.MIMEMultipartAttachment, error) {
+			func (service *{{$privateType}}) {{makePublic .Name | replaceReservedWords}} ({{if ne $requestType ""}}request *{{$requestType}}{{end}}) ({{if ne $responseType ""}}*{{$responseType}}, {{end}}[]soap.MIMEMultipartAttachment, error) {
 				return service.{{makePublic .Name | replaceReservedWords}}Context(
 					context.Background(),
 					{{if ne $requestType ""}}request,{{end}}

--- a/soap/soap.go
+++ b/soap/soap.go
@@ -12,6 +12,14 @@ import (
 	"time"
 )
 
+type AnyType struct {
+	InnerXML string `xml:",innerxml"`
+}
+
+type AnyURI string
+
+type NCName string
+
 type SOAPEncoder interface {
 	Encode(v interface{}) error
 	Flush() error

--- a/soap/soap.go
+++ b/soap/soap.go
@@ -7,7 +7,6 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"time"
@@ -503,7 +502,7 @@ func (s *Client) call(ctx context.Context, soapAction string, request, response 
 	defer res.Body.Close()
 
 	if res.StatusCode >= 400 && res.StatusCode != 500 {
-		body, _ := ioutil.ReadAll(res.Body)
+		body, _ := io.ReadAll(res.Body)
 		return &HTTPError{
 			StatusCode:   res.StatusCode,
 			ResponseBody: body,
@@ -526,11 +525,9 @@ func (s *Client) call(ctx context.Context, soapAction string, request, response 
 	}
 
 	var mmaBoundary string
-	if s.opts.mma{
-		mmaBoundary, err = getMmaHeader(res.Header.Get("Content-Type"))
-		if err != nil {
-			return err
-		}
+	mmaBoundary, err = getMmaHeader(res.Header.Get("Content-Type"))
+	if err != nil {
+		return err
 	}
 
 	// we need to store the body in case of an error

--- a/soap/soap.go
+++ b/soap/soap.go
@@ -399,27 +399,29 @@ func (s *Client) SetHttpClientHeaders(headers map[string]string) {
 
 // CallContext performs HTTP POST request with a context
 func (s *Client) CallContext(ctx context.Context, soapAction string, request, response interface{}) error {
-	return s.call(ctx, soapAction, request, response, nil, nil)
+	_, err := s.call(ctx, soapAction, request, response, nil)
+	return err
 }
 
 // Call performs HTTP POST request.
 // Note that if the server returns a status code >= 400, a HTTPError will be returned
 func (s *Client) Call(soapAction string, request, response interface{}) error {
-	return s.call(context.Background(), soapAction, request, response, nil, nil)
+	_, err := s.call(context.Background(), soapAction, request, response, nil)
+	return err
 }
 
 // CallContextWithAttachmentsAndFaultDetail performs HTTP POST request.
 // Note that if SOAP fault is returned, it will be stored in the error.
 // On top the attachments array will be filled with attachments returned from the SOAP request.
-func (s *Client) CallContextWithAttachmentsAndFaultDetail(ctx context.Context, soapAction string, request,
-	response interface{}, faultDetail FaultError, attachments *[]MIMEMultipartAttachment) error {
-	return s.call(ctx, soapAction, request, response, faultDetail, attachments)
+func (s *Client) CallContextWithAttachmentsAndFaultDetail(ctx context.Context, soapAction string, request, response interface{}, faultDetail FaultError) ([]MIMEMultipartAttachment, error) {
+	return s.call(ctx, soapAction, request, response, faultDetail)
 }
 
 // CallContextWithFault performs HTTP POST request.
 // Note that if SOAP fault is returned, it will be stored in the error.
 func (s *Client) CallContextWithFaultDetail(ctx context.Context, soapAction string, request, response interface{}, faultDetail FaultError) error {
-	return s.call(ctx, soapAction, request, response, faultDetail, nil)
+	_, err := s.call(ctx, soapAction, request, response, faultDetail)
+	return err
 }
 
 // CallWithFaultDetail performs HTTP POST request.
@@ -427,17 +429,17 @@ func (s *Client) CallContextWithFaultDetail(ctx context.Context, soapAction stri
 // the passed in fault detail is expected to implement FaultError interface,
 // which allows to condense the detail into a short error message.
 func (s *Client) CallWithFaultDetail(soapAction string, request, response interface{}, faultDetail FaultError) error {
-	return s.call(context.Background(), soapAction, request, response, faultDetail, nil)
+	_, err := s.call(context.Background(), soapAction, request, response, faultDetail)
+	return err
 }
 
-func (s *Client) call(ctx context.Context, soapAction string, request, response interface{}, faultDetail FaultError,
-	retAttachments *[]MIMEMultipartAttachment) error {
+func (s *Client) call(ctx context.Context, soapAction string, request, response interface{}, faultDetail FaultError) ([]MIMEMultipartAttachment, error) {
 	// SOAP envelope capable of namespace prefixes
 	envelope := SOAPEnvelope{
 		XmlNS: XmlNsSoapEnv,
 	}
 
-	if s.headers != nil && len(s.headers) > 0 {
+	if len(s.headers) > 0 {
 		envelope.Header = &SOAPHeader{
 			Headers: s.headers,
 		}
@@ -447,7 +449,7 @@ func (s *Client) call(ctx context.Context, soapAction string, request, response 
 	buffer := new(bytes.Buffer)
 	var encoder SOAPEncoder
 	if s.opts.mtom && s.opts.mma {
-		return fmt.Errorf("cannot use MTOM (XOP) and MMA (MIME Multipart Attachments) option at the same time")
+		return nil, fmt.Errorf("cannot use MTOM (XOP) and MMA (MIME Multipart Attachments) option at the same time")
 	} else if s.opts.mtom {
 		encoder = newMtomEncoder(buffer)
 	} else if s.opts.mma {
@@ -457,16 +459,16 @@ func (s *Client) call(ctx context.Context, soapAction string, request, response 
 	}
 
 	if err := encoder.Encode(envelope); err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := encoder.Flush(); err != nil {
-		return err
+		return nil, err
 	}
 
 	req, err := http.NewRequest("POST", s.url, buffer)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if s.opts.auth != nil {
 		req.SetBasicAuth(s.opts.auth.Login, s.opts.auth.Password)
@@ -505,13 +507,13 @@ func (s *Client) call(ctx context.Context, soapAction string, request, response 
 
 	res, err := client.Do(req)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer res.Body.Close()
 
 	if res.StatusCode >= 400 && res.StatusCode != 500 {
 		body, _ := io.ReadAll(res.Body)
-		return &HTTPError{
+		return nil, &HTTPError{
 			StatusCode:   res.StatusCode,
 			ResponseBody: body,
 		}
@@ -529,13 +531,13 @@ func (s *Client) call(ctx context.Context, soapAction string, request, response 
 
 	mtomBoundary, err := getMtomHeader(res.Header.Get("Content-Type"))
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	var mmaBoundary string
 	mmaBoundary, err = getMmaHeader(res.Header.Get("Content-Type"))
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// we need to store the body in case of an error
@@ -545,7 +547,7 @@ func (s *Client) call(ctx context.Context, soapAction string, request, response 
 	if res.StatusCode == 500 {
 		cachedErrorBody, err = io.ReadAll(res.Body)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		body = io.NopCloser(bytes.NewReader(cachedErrorBody))
 	}
@@ -562,16 +564,13 @@ func (s *Client) call(ctx context.Context, soapAction string, request, response 
 	if err := dec.Decode(respEnvelope); err != nil {
 		// the response doesn't contain a Fault/SOAPBody, so we return the original body
 		if res.StatusCode == 500 {
-			return &HTTPError{
+			return nil, &HTTPError{
 				StatusCode:   res.StatusCode,
 				ResponseBody: cachedErrorBody,
 			}
 		}
-		return err
+		return nil, err
 	}
 
-	if respEnvelope.Attachments != nil {
-		*retAttachments = respEnvelope.Attachments
-	}
-	return respEnvelope.Body.ErrorFromFault()
+	return respEnvelope.Attachments, respEnvelope.Body.ErrorFromFault()
 }

--- a/soap/soap_test.go
+++ b/soap/soap_test.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/xml"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -138,7 +138,7 @@ func TestClient_Attachments_WithAttachmentResponse(t *testing.T) {
 		for k, v := range r.Header {
 			w.Header().Set(k, v[0])
 		}
-		bodyBuf, _ := ioutil.ReadAll(r.Body)
+		bodyBuf, _ := io.ReadAll(r.Body)
 		_, err := w.Write(bodyBuf)
 		if err != nil {
 			panic(err)
@@ -183,7 +183,7 @@ func TestClient_MTOM(t *testing.T) {
 		for k, v := range r.Header {
 			w.Header().Set(k, v[0])
 		}
-		bodyBuf, _ := ioutil.ReadAll(r.Body)
+		bodyBuf, _ := io.ReadAll(r.Body)
 		w.Write(bodyBuf)
 	}))
 	defer ts.Close()
@@ -247,8 +247,7 @@ func Test_SimpleNode(t *testing.T) {
   <Num>6.005</Num>
 </SimpleNode>`
 	decoder := xml.NewDecoder(strings.NewReader(input))
-	var simple interface{}
-	simple = &SimpleNode{}
+	simple := &SimpleNode{}
 	if err := decoder.Decode(&simple); err != nil {
 		t.Fatalf("error decoding: %v", err)
 	}

--- a/soap/soap_test.go
+++ b/soap/soap_test.go
@@ -163,11 +163,10 @@ func TestClient_Attachments_WithAttachmentResponse(t *testing.T) {
 		ContentID: "First_Attachment",
 	}
 	reply := new(AttachmentRequest)
-	retAttachments := make([]MIMEMultipartAttachment, 0)
+	retAttachments, err := client.CallContextWithAttachmentsAndFaultDetail(context.TODO(), "''", req, reply, nil)
 
 	// WHEN
-	if err := client.CallContextWithAttachmentsAndFaultDetail(context.TODO(), "''", req,
-		reply, nil, &retAttachments); err != nil {
+	if err != nil {
 		t.Fatalf("couln't call service: %v", err)
 	}
 


### PR DESCRIPTION
Code for response attachment retrieval can be generated by the gowsdl tool. You have only to mark as attached the corresponding return message part.

`<wsdl:message name="downloadDocumentoResponse">`
`  <wsdl:part name="return-attachment" element="tns:downloadDocumentoResponse"/>`
`</wsdl:message>`

During code generation the corresponding operation will be invoked using the `CallContextWithAttachmentsAndFaultDetail` method of the `soap.Client` instead of the usual `CallContext` method.

Flags have been introduced to control code generation
- server (default false) enable/disable server stub code generation
- client (default true) enable/disable client stub code generation
- unqualified (default false) disable qualified name generation for element attributes